### PR TITLE
fix(trace): prevent StartAgentExecute overwrite and populate Request.Messages

### DIFF
--- a/llm/claude/trace_integration_test.go
+++ b/llm/claude/trace_integration_test.go
@@ -1,0 +1,76 @@
+package claude_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gollem/llm/claude"
+	"github.com/m-mizutani/gollem/trace"
+	"github.com/m-mizutani/gt"
+)
+
+func TestClaudeTraceIntegration(t *testing.T) {
+	apiKey, ok := os.LookupEnv("TEST_CLAUDE_API_KEY")
+	if !ok {
+		t.Skip("TEST_CLAUDE_API_KEY is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client, err := claude.New(ctx, apiKey)
+	gt.NoError(t, err)
+
+	// Create recorder and inject into context
+	rec := trace.New()
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootCtx = trace.WithHandler(rootCtx, rec)
+
+	session, err := client.NewSession(rootCtx)
+	gt.NoError(t, err)
+
+	result, err := session.Generate(rootCtx, []gollem.Input{gollem.Text("Say hello in one word")}, gollem.WithMaxTokens(maxTestTokens))
+	gt.NoError(t, err)
+	gt.A(t, result.Texts).Longer(0)
+
+	rec.EndAgentExecute(rootCtx, nil)
+
+	// Verify trace data
+	tr := rec.Trace()
+	gt.Value(t, tr).NotNil()
+
+	rootSpan := tr.RootSpan
+	gt.Value(t, rootSpan).NotNil()
+	gt.Equal(t, rootSpan.Kind, trace.SpanKindAgentExecute)
+
+	// Should have at least one LLM call child
+	gt.A(t, rootSpan.Children).Longer(0)
+
+	llmSpan := rootSpan.Children[0]
+	gt.Equal(t, llmSpan.Kind, trace.SpanKindLLMCall)
+	gt.Value(t, llmSpan.LLMCall).NotNil()
+
+	// Verify request data
+	gt.Value(t, llmSpan.LLMCall.Request).NotNil()
+	gt.A(t, llmSpan.LLMCall.Request.Messages).Longer(0)
+
+	// The last message should be user with our input text
+	lastMsg := llmSpan.LLMCall.Request.Messages[len(llmSpan.LLMCall.Request.Messages)-1]
+	gt.Equal(t, lastMsg.Role, "user")
+	gt.A(t, lastMsg.Contents).Longer(0)
+	gt.Equal(t, lastMsg.Contents[0].Type, "text")
+	gt.S(t, lastMsg.Contents[0].Text).Contains("hello")
+
+	// Verify response data
+	gt.Value(t, llmSpan.LLMCall.Response).NotNil()
+	gt.A(t, llmSpan.LLMCall.Response.Texts).Longer(0)
+
+	// Verify token counts
+	gt.N(t, llmSpan.LLMCall.InputTokens).Greater(0)
+	gt.N(t, llmSpan.LLMCall.OutputTokens).Greater(0)
+
+	// Verify model is set
+	gt.S(t, llmSpan.LLMCall.Model).NotEqual("")
+}

--- a/llm/gemini/trace_integration_test.go
+++ b/llm/gemini/trace_integration_test.go
@@ -1,0 +1,86 @@
+package gemini_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gollem/llm/gemini"
+	"github.com/m-mizutani/gollem/trace"
+	"github.com/m-mizutani/gt"
+)
+
+func TestGeminiTraceIntegration(t *testing.T) {
+	testProjectID, ok := os.LookupEnv("TEST_GCP_PROJECT_ID")
+	if !ok {
+		t.Skip("TEST_GCP_PROJECT_ID is not set")
+	}
+
+	testLocation, ok := os.LookupEnv("TEST_GCP_LOCATION")
+	if !ok {
+		t.Skip("TEST_GCP_LOCATION is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	var opts []gemini.Option
+	if model := os.Getenv("TEST_GCP_MODEL"); model != "" {
+		opts = append(opts, gemini.WithModel(model))
+	}
+
+	client, err := gemini.New(ctx, testProjectID, testLocation, opts...)
+	gt.NoError(t, err)
+
+	// Create recorder and inject into context
+	rec := trace.New()
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootCtx = trace.WithHandler(rootCtx, rec)
+
+	session, err := client.NewSession(rootCtx)
+	gt.NoError(t, err)
+
+	result, err := session.Generate(rootCtx, []gollem.Input{gollem.Text("Say hello in one word")}, gollem.WithMaxTokens(maxTestTokens))
+	gt.NoError(t, err).Required()
+	gt.A(t, result.Texts).Longer(0)
+
+	rec.EndAgentExecute(rootCtx, nil)
+
+	// Verify trace data
+	tr := rec.Trace()
+	gt.Value(t, tr).NotNil()
+
+	rootSpan := tr.RootSpan
+	gt.Value(t, rootSpan).NotNil()
+	gt.Equal(t, rootSpan.Kind, trace.SpanKindAgentExecute)
+
+	// Should have at least one LLM call child
+	gt.A(t, rootSpan.Children).Longer(0)
+
+	llmSpan := rootSpan.Children[0]
+	gt.Equal(t, llmSpan.Kind, trace.SpanKindLLMCall)
+	gt.Value(t, llmSpan.LLMCall).NotNil()
+
+	// Verify request data
+	gt.Value(t, llmSpan.LLMCall.Request).NotNil()
+	gt.A(t, llmSpan.LLMCall.Request.Messages).Longer(0)
+
+	// The last message should be user with our input text
+	lastMsg := llmSpan.LLMCall.Request.Messages[len(llmSpan.LLMCall.Request.Messages)-1]
+	gt.Equal(t, lastMsg.Role, "user")
+	gt.A(t, lastMsg.Contents).Longer(0)
+	gt.Equal(t, lastMsg.Contents[0].Type, "text")
+	gt.S(t, lastMsg.Contents[0].Text).Contains("hello")
+
+	// Verify response data
+	gt.Value(t, llmSpan.LLMCall.Response).NotNil()
+	gt.A(t, llmSpan.LLMCall.Response.Texts).Longer(0)
+
+	// Verify token counts
+	gt.N(t, llmSpan.LLMCall.InputTokens).Greater(0)
+	gt.N(t, llmSpan.LLMCall.OutputTokens).Greater(0)
+
+	// Verify model is set
+	gt.S(t, llmSpan.LLMCall.Model).NotEqual("")
+}

--- a/llm/openai/trace_integration_test.go
+++ b/llm/openai/trace_integration_test.go
@@ -1,0 +1,82 @@
+package openai_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/m-mizutani/gollem"
+	"github.com/m-mizutani/gollem/llm/openai"
+	"github.com/m-mizutani/gollem/trace"
+	"github.com/m-mizutani/gt"
+)
+
+func TestOpenAITraceIntegration(t *testing.T) {
+	apiKey, ok := os.LookupEnv("TEST_OPENAI_API_KEY")
+	if !ok {
+		t.Skip("TEST_OPENAI_API_KEY is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client, err := openai.New(ctx, apiKey)
+	gt.NoError(t, err)
+
+	// Create recorder and inject into context
+	rec := trace.New()
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootCtx = trace.WithHandler(rootCtx, rec)
+
+	session, err := client.NewSession(rootCtx)
+	gt.NoError(t, err)
+
+	result, err := session.Generate(rootCtx, []gollem.Input{gollem.Text("Say hello in one word")}, gollem.WithMaxTokens(maxTestTokens))
+	gt.NoError(t, err)
+	gt.A(t, result.Texts).Longer(0)
+
+	rec.EndAgentExecute(rootCtx, nil)
+
+	// Verify trace data
+	tr := rec.Trace()
+	gt.Value(t, tr).NotNil()
+
+	rootSpan := tr.RootSpan
+	gt.Value(t, rootSpan).NotNil()
+	gt.Equal(t, rootSpan.Kind, trace.SpanKindAgentExecute)
+
+	// Should have at least one LLM call child
+	gt.A(t, rootSpan.Children).Longer(0)
+
+	llmSpan := rootSpan.Children[0]
+	gt.Equal(t, llmSpan.Kind, trace.SpanKindLLMCall)
+	gt.Value(t, llmSpan.LLMCall).NotNil()
+
+	// Verify request data
+	gt.Value(t, llmSpan.LLMCall.Request).NotNil()
+	gt.A(t, llmSpan.LLMCall.Request.Messages).Longer(0)
+
+	// Find the user message with our input
+	var foundUserMsg bool
+	for _, msg := range llmSpan.LLMCall.Request.Messages {
+		if msg.Role == "user" {
+			for _, c := range msg.Contents {
+				if c.Type == "text" && c.Text != "" {
+					foundUserMsg = true
+				}
+			}
+		}
+	}
+	gt.B(t, foundUserMsg).True()
+
+	// Verify response data
+	gt.Value(t, llmSpan.LLMCall.Response).NotNil()
+	gt.A(t, llmSpan.LLMCall.Response.Texts).Longer(0)
+
+	// Verify token counts
+	gt.N(t, llmSpan.LLMCall.InputTokens).Greater(0)
+	gt.N(t, llmSpan.LLMCall.OutputTokens).Greater(0)
+
+	// Verify model is set
+	gt.S(t, llmSpan.LLMCall.Model).NotEqual("")
+}

--- a/trace/multi_agent_test.go
+++ b/trace/multi_agent_test.go
@@ -1,0 +1,210 @@
+package trace_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-mizutani/gollem/trace"
+	"github.com/m-mizutani/gt"
+)
+
+// TestMultiAgentExecuteSharedRecorder simulates the pattern where a user creates
+// a Recorder, starts a root trace, then passes the same Recorder to multiple
+// Agent.Execute calls (each of which calls StartAgentExecute internally).
+func TestMultiAgentExecuteSharedRecorder(t *testing.T) {
+	rec := trace.New()
+	ctx := context.Background()
+
+	// User creates root trace
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootCtx = trace.WithHandler(rootCtx, rec)
+	rootSpan := trace.CurrentSpanFrom(rootCtx)
+
+	// Simulate first Agent.Execute: calls StartAgentExecute on the same recorder
+	agent1Ctx := rec.StartAgentExecute(rootCtx)
+	agent1Span := trace.CurrentSpanFrom(agent1Ctx)
+
+	// Agent 1 makes LLM calls
+	llm1Ctx := rec.StartLLMCall(agent1Ctx)
+	rec.EndLLMCall(llm1Ctx, &trace.LLMCallData{
+		InputTokens:  100,
+		OutputTokens: 50,
+		Model:        "claude-3-sonnet",
+		Request: &trace.LLMRequest{
+			SystemPrompt: "You are helpful",
+			Messages: []trace.Message{
+				{Role: "user", Contents: []trace.MessageContent{{Type: "text", Text: "Hello"}}},
+			},
+		},
+		Response: &trace.LLMResponse{
+			Texts: []string{"Hi there!"},
+		},
+	}, nil)
+
+	// Agent 1 uses a tool
+	toolCtx := rec.StartToolExec(agent1Ctx, "search", map[string]any{"q": "test"})
+	rec.EndToolExec(toolCtx, map[string]any{"result": "found"}, nil)
+
+	// Agent 1 makes another LLM call after tool
+	llm1bCtx := rec.StartLLMCall(agent1Ctx)
+	rec.EndLLMCall(llm1bCtx, &trace.LLMCallData{
+		InputTokens:  200,
+		OutputTokens: 100,
+		Model:        "claude-3-sonnet",
+	}, nil)
+
+	rec.EndAgentExecute(agent1Ctx, nil)
+
+	// Simulate second Agent.Execute: calls StartAgentExecute again
+	agent2Ctx := rec.StartAgentExecute(rootCtx)
+	agent2Span := trace.CurrentSpanFrom(agent2Ctx)
+
+	// Agent 2 makes LLM calls
+	llm2Ctx := rec.StartLLMCall(agent2Ctx)
+	rec.EndLLMCall(llm2Ctx, &trace.LLMCallData{
+		InputTokens:  150,
+		OutputTokens: 75,
+		Model:        "claude-3-sonnet",
+		Request: &trace.LLMRequest{
+			Messages: []trace.Message{
+				{Role: "user", Contents: []trace.MessageContent{{Type: "text", Text: "Summarize"}}},
+			},
+		},
+		Response: &trace.LLMResponse{
+			Texts: []string{"Here is a summary..."},
+		},
+	}, nil)
+
+	rec.EndAgentExecute(agent2Ctx, nil)
+	rec.EndAgentExecute(rootCtx, nil)
+
+	// === Verification ===
+
+	// Root trace should exist and be intact
+	tr := rec.Trace()
+	gt.Value(t, tr).NotNil()
+	gt.Equal(t, tr.RootSpan, rootSpan)
+
+	// Root span should have 2 children (both agent_execute)
+	gt.A(t, rootSpan.Children).Length(2)
+
+	// First child: agent1
+	gt.Equal(t, rootSpan.Children[0], agent1Span)
+	gt.Equal(t, agent1Span.Kind, trace.SpanKindAgentExecute)
+	gt.Equal(t, agent1Span.ParentID, rootSpan.SpanID)
+
+	// Agent 1 should have 3 children: LLM, Tool, LLM
+	gt.A(t, agent1Span.Children).Length(3)
+	gt.Equal(t, agent1Span.Children[0].Kind, trace.SpanKindLLMCall)
+	gt.Equal(t, agent1Span.Children[0].LLMCall.InputTokens, 100)
+	gt.A(t, agent1Span.Children[0].LLMCall.Request.Messages).Length(1)
+	gt.Equal(t, agent1Span.Children[0].LLMCall.Request.Messages[0].Contents[0].Text, "Hello")
+	gt.Equal(t, agent1Span.Children[1].Kind, trace.SpanKindToolExec)
+	gt.Equal(t, agent1Span.Children[1].ToolExec.ToolName, "search")
+	gt.Equal(t, agent1Span.Children[2].Kind, trace.SpanKindLLMCall)
+	gt.Equal(t, agent1Span.Children[2].LLMCall.InputTokens, 200)
+
+	// Second child: agent2
+	gt.Equal(t, rootSpan.Children[1], agent2Span)
+	gt.Equal(t, agent2Span.Kind, trace.SpanKindAgentExecute)
+	gt.Equal(t, agent2Span.ParentID, rootSpan.SpanID)
+
+	// Agent 2 should have 1 child: LLM
+	gt.A(t, agent2Span.Children).Length(1)
+	gt.Equal(t, agent2Span.Children[0].Kind, trace.SpanKindLLMCall)
+	gt.Equal(t, agent2Span.Children[0].LLMCall.InputTokens, 150)
+	gt.A(t, agent2Span.Children[0].LLMCall.Request.Messages).Length(1)
+	gt.Equal(t, agent2Span.Children[0].LLMCall.Request.Messages[0].Contents[0].Text, "Summarize")
+
+	// All spans should be terminated
+	gt.B(t, rootSpan.Duration > 0).True()
+	gt.B(t, agent1Span.Duration > 0).True()
+	gt.B(t, agent2Span.Duration > 0).True()
+}
+
+// TestAsChildAgentVsDirectRecorder verifies that using AsChildAgent wrapper
+// produces the same result as the Recorder's built-in child fallback.
+func TestAsChildAgentVsDirectRecorder(t *testing.T) {
+	t.Run("direct recorder fallback", func(t *testing.T) {
+		rec := trace.New()
+		ctx := context.Background()
+
+		rootCtx := rec.StartAgentExecute(ctx)
+		rootSpan := trace.CurrentSpanFrom(rootCtx)
+
+		// Pass recorder directly (triggers fallback)
+		childCtx := rec.StartAgentExecute(rootCtx)
+		childSpan := trace.CurrentSpanFrom(childCtx)
+
+		llmCtx := rec.StartLLMCall(childCtx)
+		rec.EndLLMCall(llmCtx, &trace.LLMCallData{InputTokens: 42}, nil)
+
+		rec.EndAgentExecute(childCtx, nil)
+		rec.EndAgentExecute(rootCtx, nil)
+
+		// Verify structure
+		gt.A(t, rootSpan.Children).Length(1)
+		gt.Equal(t, rootSpan.Children[0], childSpan)
+		gt.Equal(t, childSpan.Kind, trace.SpanKindAgentExecute)
+		gt.A(t, childSpan.Children).Length(1)
+		gt.Equal(t, childSpan.Children[0].LLMCall.InputTokens, 42)
+	})
+
+	t.Run("AsChildAgent wrapper", func(t *testing.T) {
+		rec := trace.New()
+		ctx := context.Background()
+
+		rootCtx := rec.StartAgentExecute(ctx)
+		rootSpan := trace.CurrentSpanFrom(rootCtx)
+
+		// Use AsChildAgent wrapper
+		childHandler := trace.AsChildAgent(rec, "task-1")
+		childCtx := childHandler.StartAgentExecute(rootCtx)
+		childSpan := trace.CurrentSpanFrom(childCtx)
+
+		llmCtx := childHandler.StartLLMCall(childCtx)
+		childHandler.EndLLMCall(llmCtx, &trace.LLMCallData{InputTokens: 42}, nil)
+
+		childHandler.EndAgentExecute(childCtx, nil)
+		rec.EndAgentExecute(rootCtx, nil)
+
+		// Verify structure - should be same as direct
+		gt.A(t, rootSpan.Children).Length(1)
+		gt.Equal(t, rootSpan.Children[0], childSpan)
+		gt.Equal(t, childSpan.Kind, trace.SpanKindAgentExecute)
+		gt.A(t, childSpan.Children).Length(1)
+		gt.Equal(t, childSpan.Children[0].LLMCall.InputTokens, 42)
+	})
+}
+
+// TestRecorderFinishPreservesTrace verifies that calling Finish does not
+// clear the trace, allowing further StartAgentExecute calls to still
+// fall back to child spans.
+func TestRecorderFinishPreservesTrace(t *testing.T) {
+	dir := t.TempDir()
+	repo := trace.NewFileRepository(dir)
+	rec := trace.New(trace.WithRepository(repo))
+	ctx := context.Background()
+
+	rootCtx := rec.StartAgentExecute(ctx)
+
+	// Simulate Agent.Execute finishing (calls Finish)
+	err := rec.Finish(ctx)
+	gt.NoError(t, err)
+
+	// Trace should still be accessible
+	gt.Value(t, rec.Trace()).NotNil()
+
+	// Second StartAgentExecute should still create child
+	childCtx := rec.StartAgentExecute(rootCtx)
+	childSpan := trace.CurrentSpanFrom(childCtx)
+	gt.Value(t, childSpan).NotNil()
+	gt.Equal(t, childSpan.Kind, trace.SpanKindAgentExecute)
+
+	rootSpan := rec.Trace().RootSpan
+	gt.A(t, rootSpan.Children).Length(1)
+	gt.Equal(t, rootSpan.Children[0], childSpan)
+
+	rec.EndAgentExecute(childCtx, nil)
+	rec.EndAgentExecute(rootCtx, nil)
+}

--- a/trace/recorder.go
+++ b/trace/recorder.go
@@ -94,9 +94,36 @@ func newSpanID() string {
 }
 
 // StartAgentExecute starts the root agent_execute span.
+// If a trace already exists, it falls back to creating a child agent span
+// instead of overwriting the existing trace. This prevents silent data loss
+// when a single Recorder is shared across multiple Agent.Execute calls.
 func (r *Recorder) StartAgentExecute(ctx context.Context) context.Context {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	// If a trace already exists, fall back to child agent span
+	if r.trace != nil {
+		parent := currentSpanFrom(ctx)
+		if parent == nil {
+			return ctx
+		}
+
+		spanID := newSpanID()
+		span := &Span{
+			SpanID:    spanID,
+			ParentID:  parent.SpanID,
+			Kind:      SpanKindAgentExecute,
+			Name:      "agent_execute",
+			StartedAt: time.Now(),
+			Status:    SpanStatusOK,
+		}
+		if r.stackTrace {
+			span.StackTrace = captureStackTrace(1)
+		}
+
+		parent.Children = append(parent.Children, span)
+		return withCurrentSpan(ctx, span)
+	}
 
 	now := time.Now()
 	spanID := newSpanID()

--- a/trace/recorder.go
+++ b/trace/recorder.go
@@ -105,7 +105,7 @@ func (r *Recorder) StartAgentExecute(ctx context.Context) context.Context {
 	if r.trace != nil {
 		parent := currentSpanFrom(ctx)
 		if parent == nil {
-			return ctx
+			parent = r.trace.RootSpan
 		}
 
 		spanID := newSpanID()

--- a/trace/recorder_test.go
+++ b/trace/recorder_test.go
@@ -433,3 +433,118 @@ func TestRecorderStackTraceEnabled(t *testing.T) {
 		}
 	})
 }
+
+func TestRecorderStartAgentExecuteChildFallback(t *testing.T) {
+	rec := trace.New()
+	ctx := context.Background()
+
+	// First call: creates root trace
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootSpan := trace.CurrentSpanFrom(rootCtx)
+	gt.Value(t, rootSpan).NotNil()
+	gt.Equal(t, rootSpan.Kind, trace.SpanKindAgentExecute)
+
+	tr := rec.Trace()
+	gt.Value(t, tr).NotNil()
+	originalTraceID := tr.TraceID
+
+	// Second call: should fall back to child span, NOT overwrite trace
+	childCtx := rec.StartAgentExecute(rootCtx)
+	childSpan := trace.CurrentSpanFrom(childCtx)
+	gt.Value(t, childSpan).NotNil()
+	gt.Equal(t, childSpan.Kind, trace.SpanKindAgentExecute)
+
+	// Root trace should still exist with same ID
+	gt.Equal(t, rec.Trace().TraceID, originalTraceID)
+	gt.Equal(t, rec.Trace().RootSpan, rootSpan)
+
+	// Child span should be a child of root span
+	gt.Equal(t, len(rootSpan.Children), 1)
+	gt.Equal(t, rootSpan.Children[0], childSpan)
+	gt.Equal(t, childSpan.ParentID, rootSpan.SpanID)
+
+	// End child
+	rec.EndAgentExecute(childCtx, nil)
+	gt.Equal(t, childSpan.Status, trace.SpanStatusOK)
+
+	// End root
+	rec.EndAgentExecute(rootCtx, nil)
+	gt.Equal(t, rootSpan.Status, trace.SpanStatusOK)
+}
+
+func TestRecorderStartAgentExecuteMultipleChildren(t *testing.T) {
+	rec := trace.New()
+	ctx := context.Background()
+
+	// Create root trace
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootSpan := trace.CurrentSpanFrom(rootCtx)
+
+	// First child agent
+	child1Ctx := rec.StartAgentExecute(rootCtx)
+	child1Span := trace.CurrentSpanFrom(child1Ctx)
+
+	// Add LLM call inside child1
+	llmCtx := rec.StartLLMCall(child1Ctx)
+	rec.EndLLMCall(llmCtx, &trace.LLMCallData{InputTokens: 10}, nil)
+
+	rec.EndAgentExecute(child1Ctx, nil)
+
+	// Second child agent
+	child2Ctx := rec.StartAgentExecute(rootCtx)
+	child2Span := trace.CurrentSpanFrom(child2Ctx)
+
+	// Add LLM call inside child2
+	llm2Ctx := rec.StartLLMCall(child2Ctx)
+	rec.EndLLMCall(llm2Ctx, &trace.LLMCallData{InputTokens: 20}, nil)
+
+	rec.EndAgentExecute(child2Ctx, nil)
+
+	rec.EndAgentExecute(rootCtx, nil)
+
+	// Verify tree structure
+	gt.Equal(t, len(rootSpan.Children), 2)
+	gt.Equal(t, rootSpan.Children[0], child1Span)
+	gt.Equal(t, rootSpan.Children[1], child2Span)
+
+	// Each child should have one LLM call child
+	gt.Equal(t, len(child1Span.Children), 1)
+	gt.Equal(t, child1Span.Children[0].Kind, trace.SpanKindLLMCall)
+	gt.Equal(t, child1Span.Children[0].LLMCall.InputTokens, 10)
+
+	gt.Equal(t, len(child2Span.Children), 1)
+	gt.Equal(t, child2Span.Children[0].Kind, trace.SpanKindLLMCall)
+	gt.Equal(t, child2Span.Children[0].LLMCall.InputTokens, 20)
+
+	// Original trace should be preserved
+	gt.Value(t, rec.Trace()).NotNil()
+	gt.Equal(t, rec.Trace().RootSpan, rootSpan)
+}
+
+func TestRecorderStartAgentExecuteTripleNesting(t *testing.T) {
+	rec := trace.New()
+	ctx := context.Background()
+
+	// Root
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootSpan := trace.CurrentSpanFrom(rootCtx)
+
+	// Child 1 (inside root)
+	child1Ctx := rec.StartAgentExecute(rootCtx)
+	child1Span := trace.CurrentSpanFrom(child1Ctx)
+
+	// Grandchild (inside child 1)
+	grandchildCtx := rec.StartAgentExecute(child1Ctx)
+	grandchildSpan := trace.CurrentSpanFrom(grandchildCtx)
+
+	rec.EndAgentExecute(grandchildCtx, nil)
+	rec.EndAgentExecute(child1Ctx, nil)
+	rec.EndAgentExecute(rootCtx, nil)
+
+	// Verify 3-level nesting
+	gt.Equal(t, len(rootSpan.Children), 1)
+	gt.Equal(t, rootSpan.Children[0], child1Span)
+	gt.Equal(t, len(child1Span.Children), 1)
+	gt.Equal(t, child1Span.Children[0], grandchildSpan)
+	gt.Equal(t, grandchildSpan.ParentID, child1Span.SpanID)
+}

--- a/trace/recorder_test.go
+++ b/trace/recorder_test.go
@@ -548,3 +548,30 @@ func TestRecorderStartAgentExecuteTripleNesting(t *testing.T) {
 	gt.Equal(t, child1Span.Children[0], grandchildSpan)
 	gt.Equal(t, grandchildSpan.ParentID, child1Span.SpanID)
 }
+
+func TestRecorderStartAgentExecuteFallbackToRootSpan(t *testing.T) {
+	rec := trace.New()
+	ctx := context.Background()
+
+	// Create root trace
+	rootCtx := rec.StartAgentExecute(ctx)
+	rootSpan := trace.CurrentSpanFrom(rootCtx)
+	gt.Value(t, rootSpan).NotNil()
+
+	// Call StartAgentExecute with a context that has NO current span
+	// (e.g., a fresh context without span info). It should fall back
+	// to using r.trace.RootSpan as the parent.
+	freshCtx := context.Background()
+	childCtx := rec.StartAgentExecute(freshCtx)
+	childSpan := trace.CurrentSpanFrom(childCtx)
+	gt.Value(t, childSpan).NotNil()
+	gt.Equal(t, childSpan.Kind, trace.SpanKindAgentExecute)
+	gt.Equal(t, childSpan.ParentID, rootSpan.SpanID)
+
+	// Child should be attached to root span
+	gt.Equal(t, len(rootSpan.Children), 1)
+	gt.Equal(t, rootSpan.Children[0], childSpan)
+
+	rec.EndAgentExecute(childCtx, nil)
+	rec.EndAgentExecute(rootCtx, nil)
+}


### PR DESCRIPTION
## Summary
- **Fix StartAgentExecute overwrite**: When `Recorder.StartAgentExecute` is called on a recorder that already has an active trace, it now creates a child span instead of silently overwriting the root trace. This prevents data loss when sharing a single Recorder across multiple `Agent.Execute` calls.
- **Populate Request.Messages**: All LLM providers (Claude, OpenAI, Gemini) now convert their provider-specific message formats to `trace.Message` with structured `Contents []MessageContent`, properly recording text, tool_use, and tool_result blocks in trace data.
- **Update trace.Message struct**: Changed from `Content string` to `Contents []MessageContent` to support multi-part message content (text, tool calls, tool results).
- **Frontend update**: Updated TypeScript types and LLMCallDetail component to render the new `contents` array format with backwards compatibility.

## Test plan
- [x] `StartAgentExecute` multi-call fallback tests (2-level, 3-level nesting)
- [x] Message conversion unit tests for each provider (Claude, OpenAI, Gemini)
- [x] Integration tests with real LLM calls verifying trace data (Messages, Tokens, Model)
- [x] Multi-agent shared Recorder test (simulates user pattern from issue)
- [x] `AsChildAgent` vs direct Recorder comparison test
- [x] `Finish` preserves trace for subsequent child agent creation
- [x] `zenv go test ./...` all packages pass
- [x] `golangci-lint run ./...` clean
- [x] `gosec -quiet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)