### PR TITLE
refactor(trace): record per-turn delta in LLMRequest.Messages

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -139,6 +139,10 @@ Each span contains:
 - `Status`: `ok` or `error`
 - Kind-specific data (`LLMCallData`, `ToolExecData`, `EventData`)
 
+#### LLM Call Messages
+
+`LLMCallData.Request.Messages` records only the messages newly added in that turn (e.g. the latest user input and any tool responses), not the full conversation history that was actually sent to the provider. This keeps each span proportional to the work done in that turn — the prior history can be reconstructed by walking the chronologically earlier `llm_call` spans in the same trace.
+
 ### OpenTelemetry Handler (`trace/otel`)
 
 The `trace/otel` package bridges gollem's trace events to OpenTelemetry spans. This integrates with any OTel-compatible backend such as Jaeger, Zipkin, or OTLP collectors.

--- a/llm.go
+++ b/llm.go
@@ -26,7 +26,7 @@ type FunctionCall struct {
 // Response is a general response type for each gollem.
 type Response struct {
 	Texts         []string
-	Thoughts     []string
+	Thoughts      []string
 	FunctionCalls []*FunctionCall
 	InputToken    int
 	OutputToken   int

--- a/llm/claude/client.go
+++ b/llm/claude/client.go
@@ -684,8 +684,10 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 		effectiveCT, hasSchema := effectiveContentType(s.cfg.ContentType(), s.cfg.ResponseSchema(), opts...)
 		processedResp := processResponseWithContentType(ctx, resp, effectiveCT, hasSchema)
 
-		// Set trace data for defer
-		traceData = buildClaudeTraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), apiMessages)
+		// Set trace data for defer.
+		// Record only messages added in this turn; previous turns are already
+		// captured in earlier trace spans.
+		traceData = buildClaudeTraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), messages)
 
 		// Update history with new messages (already in Claude format)
 		s.historyMessages = append(s.historyMessages, messages...)
@@ -893,8 +895,10 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 			return nil, goerr.Wrap(err, "failed to create message stream", opts...)
 		}
 
-		// Set trace data for defer
-		streamTraceData = buildClaudeTraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), allMessages)
+		// Set trace data for defer.
+		// Record only messages added in this turn; previous turns are already
+		// captured in earlier trace spans.
+		streamTraceData = buildClaudeTraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), messages)
 
 		responseChan := make(chan *gollem.ContentResponse)
 

--- a/llm/claude/client_test.go
+++ b/llm/claude/client_test.go
@@ -555,3 +555,73 @@ func TestClaudeMessagesToTraceMessages(t *testing.T) {
 		},
 	}))
 }
+
+// TestClaudeTraceRequestMessagesNewTurnOnly verifies that the trace's
+// LLMRequest.Messages contains only messages newly added in this turn,
+// not the entire conversation history that was actually sent to the API.
+func TestClaudeTraceRequestMessagesNewTurnOnly(t *testing.T) {
+	userContent, err := gollem.NewTextContent("previous question")
+	gt.NoError(t, err)
+	assistantContent, err := gollem.NewTextContent("previous answer")
+	gt.NoError(t, err)
+	history := &gollem.History{
+		Version: gollem.HistoryVersion,
+		LLType:  gollem.LLMTypeClaude,
+		Messages: []gollem.Message{
+			{Role: gollem.RoleUser, Contents: []gollem.MessageContent{userContent}},
+			{Role: gollem.RoleAssistant, Contents: []gollem.MessageContent{assistantContent}},
+		},
+	}
+
+	var sentMessages []anthropic.MessageParam
+	mockClient := &apiClientMock{
+		MessagesNewFunc: func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
+			sentMessages = params.Messages
+			return &anthropic.Message{
+				Content: []anthropic.ContentBlockUnion{
+					{Type: "text", Text: "ok"},
+				},
+				Role:  "assistant",
+				Model: "claude-3-opus-20240229",
+			}, nil
+		},
+	}
+
+	cfg := gollem.NewSessionConfig(gollem.WithSessionHistory(history))
+	session, err := claude.NewSessionWithAPIClient(mockClient, cfg, "claude-3-opus-20240229")
+	gt.NoError(t, err)
+
+	rec := trace.New()
+	ctx := rec.StartAgentExecute(context.Background())
+	ctx = trace.WithHandler(ctx, rec)
+
+	_, err = session.Generate(ctx, []gollem.Input{gollem.Text("new question")})
+	gt.NoError(t, err)
+	rec.EndAgentExecute(ctx, nil)
+
+	// Sanity check: the actual API request still includes the full history.
+	gt.N(t, len(sentMessages)).Equal(3)
+
+	// Find the LLM call span.
+	var llmSpan *trace.Span
+	for _, child := range rec.Trace().RootSpan.Children {
+		if child.Kind == trace.SpanKindLLMCall {
+			llmSpan = child
+			break
+		}
+	}
+	gt.Value(t, llmSpan).NotNil()
+
+	msgs := llmSpan.LLMCall.Request.Messages
+	gt.A(t, msgs).Length(1)
+	gt.Equal(t, "user", msgs[0].Role)
+	gt.A(t, msgs[0].Contents).Length(1)
+	gt.Equal(t, "text", msgs[0].Contents[0].Type)
+	gt.Equal(t, "new question", msgs[0].Contents[0].Text)
+
+	for _, m := range msgs {
+		for _, c := range m.Contents {
+			gt.S(t, c.Text).NotContains("previous")
+		}
+	}
+}

--- a/llm/claude/convert_message_test.go
+++ b/llm/claude/convert_message_test.go
@@ -156,7 +156,7 @@ func TestClaudeMessageRoundTrip(t *testing.T) {
 		reasoning, err := content.GetThinkingContent()
 		gt.NoError(t, err)
 		gt.Equal(t, "", reasoning.Text)
-			// Signature is stored in meta
-			gt.NotNil(t, content.Meta)
+		// Signature is stored in meta
+		gt.NotNil(t, content.Meta)
 	})
 }

--- a/llm/claude/vertex_client.go
+++ b/llm/claude/vertex_client.go
@@ -235,8 +235,10 @@ func (s *VertexAnthropicSession) Generate(ctx context.Context, input []gollem.In
 		return nil, err
 	}
 
-	// Set trace data for defer
-	traceData = buildClaudeTraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), apiMessages)
+	// Set trace data for defer.
+	// Record only messages added in this turn; previous turns are already
+	// captured in earlier trace spans.
+	traceData = buildClaudeTraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), messages)
 
 	// Only update session history after successful API call
 	s.messages = append(s.messages, messages...)
@@ -368,6 +370,9 @@ func (s *VertexAnthropicSession) Stream(ctx context.Context, input []gollem.Inpu
 			Model:        s.defaultModel,
 			Request: &trace.LLMRequest{
 				SystemPrompt: s.cfg.SystemPrompt(),
+				// Record only messages added in this turn; previous turns are
+				// already captured in earlier trace spans.
+				Messages: claudeMessagesToTraceMessages(messages),
 			},
 			Response: &trace.LLMResponse{
 				Texts:         allTexts,

--- a/llm/gemini/client.go
+++ b/llm/gemini/client.go
@@ -385,7 +385,7 @@ func processResponse(resp *genai.GenerateContentResponse) (*gollem.Response, err
 	response := &gollem.Response{
 		Texts:         make([]string, 0),
 		FunctionCalls: make([]*gollem.FunctionCall, 0),
-		Thoughts:     make([]string, 0),
+		Thoughts:      make([]string, 0),
 	}
 
 	// Extract token counts from UsageMetadata if available
@@ -476,13 +476,17 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 			return nil, err
 		}
 
-		// Add current input as a new user message
+		// Add current input as a new user message.
+		// newTurnContents tracks only the contents added in this turn so that
+		// trace data records the delta rather than the full history.
+		var newTurnContents []*genai.Content
 		if len(parts) > 0 {
 			userContent := &genai.Content{
 				Role:  "user",
 				Parts: parts,
 			}
 			contents = append(contents, userContent)
+			newTurnContents = append(newTurnContents, userContent)
 		}
 
 		// Start LLM call trace span
@@ -513,8 +517,10 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 			return nil, err
 		}
 
-		// Set trace data for defer
-		geminiTraceData = buildGeminiTraceData(response, s.model, s.cfg.SystemPrompt(), contents)
+		// Set trace data for defer.
+		// Record only contents added in this turn; previous turns are already
+		// captured in earlier trace spans.
+		geminiTraceData = buildGeminiTraceData(response, s.model, s.cfg.SystemPrompt(), newTurnContents)
 
 		// Update history with the input and raw response content.
 		// Use candidate.Content directly to preserve all fields (e.g., ThoughtSignature).
@@ -610,13 +616,17 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 			return nil, err
 		}
 
-		// Add current input as a new user message
+		// Add current input as a new user message.
+		// newTurnContents tracks only the contents added in this turn so that
+		// trace data records the delta rather than the full history.
+		var newTurnContents []*genai.Content
 		if len(parts) > 0 {
 			userContent := &genai.Content{
 				Role:  "user",
 				Parts: parts,
 			}
 			contents = append(contents, userContent)
+			newTurnContents = append(newTurnContents, userContent)
 		}
 
 		// Start LLM call trace span
@@ -732,14 +742,16 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 				}
 			}
 
-			// Set trace data for defer
+			// Set trace data for defer.
+			// Record only contents added in this turn; previous turns are
+			// already captured in earlier trace spans.
 			streamTraceData = &trace.LLMCallData{
 				InputTokens:  totalInputTokens,
 				OutputTokens: totalOutputTokens,
 				Model:        s.model,
 				Request: &trace.LLMRequest{
 					SystemPrompt: s.cfg.SystemPrompt(),
-					Messages:     contentsToTraceMessages(contents),
+					Messages:     contentsToTraceMessages(newTurnContents),
 				},
 				Response: &trace.LLMResponse{},
 			}

--- a/llm/gemini/client_test.go
+++ b/llm/gemini/client_test.go
@@ -1119,3 +1119,82 @@ func TestContentsToTraceMessages(t *testing.T) {
 		},
 	}))
 }
+
+// TestGeminiTraceRequestMessagesNewTurnOnly verifies that the trace's
+// LLMRequest.Messages contains only contents newly added in this turn,
+// not the entire conversation history that was actually sent to the API.
+func TestGeminiTraceRequestMessagesNewTurnOnly(t *testing.T) {
+	userContent, err := gollem.NewTextContent("previous question")
+	gt.NoError(t, err)
+	assistantContent, err := gollem.NewTextContent("previous answer")
+	gt.NoError(t, err)
+	history := &gollem.History{
+		Version: gollem.HistoryVersion,
+		LLType:  gollem.LLMTypeGemini,
+		Messages: []gollem.Message{
+			{Role: gollem.RoleUser, Contents: []gollem.MessageContent{userContent}},
+			{Role: gollem.RoleAssistant, Contents: []gollem.MessageContent{assistantContent}},
+		},
+	}
+
+	var sentContents []*genai.Content
+	mockClient := &apiClientMock{
+		GenerateContentFunc: func(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+			sentContents = contents
+			return &genai.GenerateContentResponse{
+				Candidates: []*genai.Candidate{
+					{
+						Content: &genai.Content{
+							Role:  "model",
+							Parts: []*genai.Part{{Text: "ok"}},
+						},
+					},
+				},
+			}, nil
+		},
+		GenerateContentStreamFunc: func(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) <-chan gemini.StreamResponse {
+			ch := make(chan gemini.StreamResponse)
+			close(ch)
+			return ch
+		},
+	}
+
+	cfg := gollem.NewSessionConfig(gollem.WithSessionHistory(history))
+	session, err := gemini.NewSessionWithAPIClient(mockClient, cfg, "gemini-1.5-pro")
+	gt.NoError(t, err)
+
+	rec := trace.New()
+	ctx := rec.StartAgentExecute(context.Background())
+	ctx = trace.WithHandler(ctx, rec)
+
+	_, err = session.Generate(ctx, []gollem.Input{gollem.Text("new question")})
+	gt.NoError(t, err)
+	rec.EndAgentExecute(ctx, nil)
+
+	// Sanity check: the actual API request still includes the full history
+	// (two prior turns + the new user message).
+	gt.N(t, len(sentContents)).Equal(3)
+
+	// Find the LLM call span.
+	var llmSpan *trace.Span
+	for _, child := range rec.Trace().RootSpan.Children {
+		if child.Kind == trace.SpanKindLLMCall {
+			llmSpan = child
+			break
+		}
+	}
+	gt.Value(t, llmSpan).NotNil()
+
+	msgs := llmSpan.LLMCall.Request.Messages
+	gt.A(t, msgs).Length(1)
+	gt.Equal(t, "user", msgs[0].Role)
+	gt.A(t, msgs[0].Contents).Length(1)
+	gt.Equal(t, "text", msgs[0].Contents[0].Type)
+	gt.Equal(t, "new question", msgs[0].Contents[0].Text)
+
+	for _, m := range msgs {
+		for _, c := range m.Contents {
+			gt.S(t, c.Text).NotContains("previous")
+		}
+	}
+}

--- a/llm/openai/client.go
+++ b/llm/openai/client.go
@@ -310,7 +310,6 @@ func (s *Session) updateHistoryWithResponse(assistantMessage openai.ChatCompleti
 	return nil
 }
 
-// convertInputs converts gollem.Input to OpenAI messages and updates currentHistory
 // convertInputsToMessages converts gollem.Input to OpenAI messages without modifying session state.
 // This is a pure function used for read-only operations like CountToken.
 func (s *Session) convertInputsToMessages(input ...gollem.Input) ([]openai.ChatCompletionMessage, error) {
@@ -386,27 +385,22 @@ func (s *Session) convertInputsToMessages(input ...gollem.Input) ([]openai.ChatC
 	return newMessages, nil
 }
 
-func (s *Session) convertInputs(input ...gollem.Input) error {
+// convertInputs converts gollem.Input to OpenAI messages, appends them to the
+// session history, and returns the newly added messages so callers (e.g. trace)
+// can record only the messages added in this turn.
+func (s *Session) convertInputs(input ...gollem.Input) ([]openai.ChatCompletionMessage, error) {
 	// Convert inputs to messages using the pure function
 	newMessages, err := s.convertInputsToMessages(input...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Update currentHistory with new messages
 	if len(newMessages) > 0 {
-		// Get current messages and append new ones
-		currentMessages, err := s.getMessages()
-		if err != nil {
-			return goerr.Wrap(err, "failed to get current messages")
-		}
-		allMessages := append(currentMessages, newMessages...)
-
-		// Update history with all messages
-		s.historyMessages = allMessages
+		s.historyMessages = append(s.historyMessages, newMessages...)
 	}
 
-	return nil
+	return newMessages, nil
 }
 
 // createRequest creates a chat completion request with the current session state
@@ -491,7 +485,8 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 		}
 
 		// Convert inputs and perform the actual API call
-		if err := s.convertInputs(req.Inputs...); err != nil {
+		newMessages, err := s.convertInputs(req.Inputs...)
+		if err != nil {
 			return nil, err
 		}
 
@@ -534,7 +529,7 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 
 		response := &gollem.Response{
 			Texts:         make([]string, 0),
-			Thoughts:     make([]string, 0),
+			Thoughts:      make([]string, 0),
 			FunctionCalls: make([]*gollem.FunctionCall, 0),
 			InputToken:    resp.Usage.PromptTokens,
 			OutputToken:   resp.Usage.CompletionTokens,
@@ -587,14 +582,16 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 			}
 		}
 
-		// Set trace data for defer
-		openaiTraceData = buildOpenAITraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), openaiReq.Messages)
+		// Set trace data for defer.
+		// Record only messages added in this turn; the full request history is
+		// captured incrementally across previous trace spans.
+		openaiTraceData = buildOpenAITraceData(resp, s.defaultModel, s.cfg.SystemPrompt(), newMessages)
 
 		// History is already updated by updateHistoryWithResponse above
 
 		return &gollem.ContentResponse{
 			Texts:         response.Texts,
-			Thoughts:     response.Thoughts,
+			Thoughts:      response.Thoughts,
 			FunctionCalls: response.FunctionCalls,
 			InputToken:    response.InputToken,
 			OutputToken:   response.OutputToken,
@@ -617,7 +614,7 @@ func (s *Session) Generate(ctx context.Context, input []gollem.Input, opts ...go
 	// Convert ContentResponse back to gollem.Response
 	return &gollem.Response{
 		Texts:         contentResp.Texts,
-		Thoughts:     contentResp.Thoughts,
+		Thoughts:      contentResp.Thoughts,
 		FunctionCalls: contentResp.FunctionCalls,
 		InputToken:    contentResp.InputToken,
 		OutputToken:   contentResp.OutputToken,
@@ -655,7 +652,8 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 		}
 
 		// Convert inputs and perform the actual API call
-		if err := s.convertInputs(req.Inputs...); err != nil {
+		newMessages, err := s.convertInputs(req.Inputs...)
+		if err != nil {
 			return nil, err
 		}
 
@@ -755,7 +753,7 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 				if delta.ReasoningContent != "" {
 					reasoningContent += delta.ReasoningContent
 					responseChan <- &gollem.ContentResponse{
-						Thoughts:   []string{delta.ReasoningContent},
+						Thoughts:    []string{delta.ReasoningContent},
 						InputToken:  totalInputTokens,
 						OutputToken: totalOutputTokens,
 					}
@@ -860,14 +858,16 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 				}
 			}
 
-			// Set trace data for defer
+			// Set trace data for defer.
+			// Record only messages added in this turn; previous turns are already
+			// captured in earlier trace spans.
 			streamTraceData = &trace.LLMCallData{
 				InputTokens:  totalInputTokens,
 				OutputTokens: totalOutputTokens,
 				Model:        s.defaultModel,
 				Request: &trace.LLMRequest{
 					SystemPrompt: s.cfg.SystemPrompt(),
-					Messages:     openaiMessagesToTraceMessages(openaiReq.Messages),
+					Messages:     openaiMessagesToTraceMessages(newMessages),
 				},
 				Response: &trace.LLMResponse{},
 			}
@@ -931,7 +931,7 @@ func (s *Session) Stream(ctx context.Context, input []gollem.Input, opts ...goll
 			} else {
 				responseChan <- &gollem.Response{
 					Texts:         streamResp.Texts,
-					Thoughts:     streamResp.Thoughts,
+					Thoughts:      streamResp.Thoughts,
 					FunctionCalls: streamResp.FunctionCalls,
 					InputToken:    streamResp.InputToken,
 					OutputToken:   streamResp.OutputToken,

--- a/llm/openai/client_test.go
+++ b/llm/openai/client_test.go
@@ -436,3 +436,92 @@ func TestThinkingContentExtraction(t *testing.T) {
 		gt.Equal(t, 15, result.OutputToken)
 	})
 }
+
+// TestOpenAITraceRequestMessagesNewTurnOnly verifies that the trace's
+// LLMRequest.Messages contains only messages newly added in this turn,
+// not the entire conversation history that was actually sent to the API.
+func TestOpenAITraceRequestMessagesNewTurnOnly(t *testing.T) {
+	makeHistory := func() *gollem.History {
+		userContent, err := gollem.NewTextContent("previous question")
+		gt.NoError(t, err)
+		assistantContent, err := gollem.NewTextContent("previous answer")
+		gt.NoError(t, err)
+		return &gollem.History{
+			Version: gollem.HistoryVersion,
+			LLType:  gollem.LLMTypeOpenAI,
+			Messages: []gollem.Message{
+				{Role: gollem.RoleUser, Contents: []gollem.MessageContent{userContent}},
+				{Role: gollem.RoleAssistant, Contents: []gollem.MessageContent{assistantContent}},
+			},
+		}
+	}
+
+	findLLMSpan := func(t *testing.T, root *trace.Span) *trace.Span {
+		t.Helper()
+		for _, child := range root.Children {
+			if child.Kind == trace.SpanKindLLMCall {
+				return child
+			}
+		}
+		t.Fatal("llm_call span not found")
+		return nil
+	}
+
+	t.Run("Generate", func(t *testing.T) {
+		var sentMessages []openaiapi.ChatCompletionMessage
+		mockClient := &apiClientMock{
+			CreateChatCompletionFunc: func(ctx context.Context, req openaiapi.ChatCompletionRequest) (openaiapi.ChatCompletionResponse, error) {
+				sentMessages = req.Messages
+				return openaiapi.ChatCompletionResponse{
+					Model: "gpt-5",
+					Choices: []openaiapi.ChatCompletionChoice{
+						{
+							Message: openaiapi.ChatCompletionMessage{
+								Role:    openaiapi.ChatMessageRoleAssistant,
+								Content: "ok",
+							},
+							FinishReason: openaiapi.FinishReasonStop,
+						},
+					},
+				}, nil
+			},
+		}
+
+		cfg := gollem.NewSessionConfig(gollem.WithSessionHistory(makeHistory()))
+		session, err := openai.NewSessionWithAPIClient(mockClient, cfg, "gpt-5")
+		gt.NoError(t, err)
+
+		rec := trace.New()
+		ctx := rec.StartAgentExecute(context.Background())
+		ctx = trace.WithHandler(ctx, rec)
+
+		_, err = session.Generate(ctx, []gollem.Input{gollem.Text("new question")})
+		gt.NoError(t, err)
+		rec.EndAgentExecute(ctx, nil)
+
+		// Sanity check: the actual API request includes the full history.
+		gt.N(t, len(sentMessages)).Equal(3)
+
+		// But the trace records only the new turn.
+		llmSpan := findLLMSpan(t, rec.Trace().RootSpan)
+		msgs := llmSpan.LLMCall.Request.Messages
+		gt.A(t, msgs).Length(1)
+		gt.Equal(t, "user", msgs[0].Role)
+		gt.A(t, msgs[0].Contents).Length(1)
+		gt.Equal(t, "text", msgs[0].Contents[0].Type)
+		gt.Equal(t, "new question", msgs[0].Contents[0].Text)
+
+		for _, m := range msgs {
+			for _, c := range m.Contents {
+				gt.S(t, c.Text).NotContains("previous")
+			}
+		}
+	})
+
+	// Note: Stream is not covered by a mock-based test because
+	// *openai.ChatCompletionStream cannot be constructed outside the SDK
+	// (it has unexported fields). The Stream code path uses the same
+	// newMessages variable and the same openaiMessagesToTraceMessages call
+	// site as Generate, so the Generate test above is structurally
+	// equivalent for the trace-delta invariant.
+}

--- a/message.go
+++ b/message.go
@@ -43,7 +43,7 @@ const (
 	MessageContentTypePDF          MessageContentType = "pdf"
 	MessageContentTypeToolCall     MessageContentType = "tool_call"
 	MessageContentTypeToolResponse MessageContentType = "tool_response"
-	MessageContentTypeThinking    MessageContentType = "thinking"
+	MessageContentTypeThinking     MessageContentType = "thinking"
 )
 
 // TextContent represents text content in a message

--- a/middleware.go
+++ b/middleware.go
@@ -26,7 +26,7 @@ type ContentRequest struct {
 // ContentResponse represents a response from content generation.
 type ContentResponse struct {
 	Texts         []string        // Generated text content
-	Thoughts     []string        // Thinking/reasoning content
+	Thoughts      []string        // Thinking/reasoning content
 	FunctionCalls []*FunctionCall // Function/tool call requests
 	InputToken    int             // Number of input tokens used
 	OutputToken   int             // Number of output tokens used


### PR DESCRIPTION
## Summary

- `LLMCallData.Request.Messages` previously contained the full message list sent to the provider (history + new turn). Each `llm_call` span therefore grew linearly with the conversation, repeating earlier messages on every turn.
- All three providers (OpenAI, Claude/Vertex, Gemini) now record only the messages newly added in the current turn. The actual API request still includes the full history — only the trace payload changes.
- `docs/tracing.md` documents the new semantics; readers can reconstruct the full history by walking earlier `llm_call` spans in the same trace.

## Implementation notes

- `llm/openai/client.go`: `Session.convertInputs` now returns the messages it appended; `Generate` / `Stream` pass that delta to `buildOpenAITraceData` / `streamTraceData` instead of `openaiReq.Messages`.
- `llm/claude/client.go` and `llm/claude/vertex_client.go`: `buildClaudeTraceData` / stream trace data is fed the per-turn `messages` slice rather than `apiMessages` / `allMessages`. Vertex `Stream` previously left `Request.Messages` empty; it now also records the new turn.
- `llm/gemini/client.go`: `Generate` / `Stream` track a `newTurnContents` slice for the trace payload while still sending the full `contents` to the API.
- `go fmt ./...` cleaned up pre-existing alignment drift in `llm.go`, `message.go`, `middleware.go`, and `llm/claude/convert_message_test.go`; included alongside the main change.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New unit tests assert that, with a pre-populated history, the API request still carries the full history while `LLMCall.Request.Messages` contains only the new user input — no leakage of prior turns:
  - `llm/openai/client_test.go::TestOpenAITraceRequestMessagesNewTurnOnly`
  - `llm/claude/client_test.go::TestClaudeTraceRequestMessagesNewTurnOnly`
  - `llm/gemini/client_test.go::TestGeminiTraceRequestMessagesNewTurnOnly`

OpenAI `Stream` is not covered by a mock-based test because `*openai.ChatCompletionStream` cannot be constructed outside the SDK; the comment in the test file explains why the `Generate` test is structurally equivalent.