### PR TITLE
feat: support Gemini 3.x strict tool-call id matching and thinking levels

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -46,7 +46,7 @@ client, err := gemini.New(ctx, projectID, location,
 )
 ```
 
-Available models:
+Available models (default: `gemini-3.5-flash`):
 - `gemini-3.5-flash` - Latest Flash model with improved agent execution and coding (uses thinking levels)
 - `gemini-2.5-pro` - Advanced model with state-of-the-art thinking capabilities
 - `gemini-2.5-flash` - Strong price-performance model with well-rounded capabilities

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -47,17 +47,40 @@ client, err := gemini.New(ctx, projectID, location,
 ```
 
 Available models:
-- `gemini-2.5-pro` - Most advanced model with state-of-the-art thinking capabilities
-- `gemini-2.5-flash` - Best price-performance model with well-rounded capabilities
+- `gemini-3.5-flash` - Latest Flash model with improved agent execution and coding (uses thinking levels)
+- `gemini-2.5-pro` - Advanced model with state-of-the-art thinking capabilities
+- `gemini-2.5-flash` - Strong price-performance model with well-rounded capabilities
 - `gemini-2.5-flash-lite` - Optimized for cost efficiency and low latency
 - `gemini-2.0-flash` - Superior speed with native tool use and 1M token context
 - `gemini-2.0-flash-thinking-exp-1219` - Experimental model with thinking capabilities
 
 Note: Gemini 1.5 models are deprecated as of April 2025 for new projects.
 
-#### Thinking Budget (Gemini 2.0)
+#### Thinking Level (Gemini 3.x)
 
-Control the model's internal reasoning process:
+Gemini 3.x replaces the numeric `thinking_budget` with a discrete `thinking_level`:
+
+```go
+// Use minimal thinking for fast, simple responses
+client, err := gemini.New(ctx, projectID, location,
+    gemini.WithModel("gemini-3.5-flash"),
+    gemini.WithThinkingLevel(genai.ThinkingLevelMinimal),
+)
+
+// Use higher levels for harder reasoning tasks
+client, err := gemini.New(ctx, projectID, location,
+    gemini.WithModel("gemini-3.5-flash"),
+    gemini.WithThinkingLevel(genai.ThinkingLevelHigh),
+)
+```
+
+Available levels (lowest → highest): `ThinkingLevelMinimal`, `ThinkingLevelLow`, `ThinkingLevelMedium`, `ThinkingLevelHigh`. The default is `medium`.
+
+Note: Gemini 3.x also deprecates `temperature`, `top_p`, and `top_k` — omit those options when using 3.x models.
+
+#### Thinking Budget (Gemini 2.x)
+
+For Gemini 2.x models, control thinking via a numeric token budget:
 
 ```go
 // Automatic thinking budget (model decides based on complexity)

--- a/history_test.go
+++ b/history_test.go
@@ -439,7 +439,7 @@ func TestGeminiToOpenAIConversion(t *testing.T) {
 			{
 				Role: "assistant",
 				ToolCalls: []openaiSDK.ToolCall{{
-					ID:   "call_search_0",
+					ID:   "gemini-fallback-search-0",
 					Type: "function",
 					Function: openaiSDK.FunctionCall{
 						Name:      "search",
@@ -450,7 +450,7 @@ func TestGeminiToOpenAIConversion(t *testing.T) {
 			{
 				Role:       "tool",
 				Content:    `{"results":[{"title":"Python Basics","url":"https://example.com/1"},{"title":"Learn Python","url":"https://example.com/2"}],"total":2}`,
-				ToolCallID: "call_search_0",
+				ToolCallID: "gemini-fallback-search-0",
 				Name:       "search",
 			},
 			{Role: "assistant", Content: "I found 2 Python tutorials for beginners."},

--- a/history_test.go
+++ b/history_test.go
@@ -239,16 +239,18 @@ func TestClaudeToGeminiConversion(t *testing.T) {
 			{
 				Role: "model",
 				Parts: []*genai.Part{
-					{FunctionCall: &genai.FunctionCall{Name: "calculate", Args: map[string]any{"expression": "5+3"}}},
-					{FunctionCall: &genai.FunctionCall{Name: "calculate", Args: map[string]any{"expression": "10*2"}}},
+					// Claude's tool_use IDs must be propagated to Gemini for
+					// Gemini 3.x strict id matching.
+					{FunctionCall: &genai.FunctionCall{ID: "toolu_123", Name: "calculate", Args: map[string]any{"expression": "5+3"}}},
+					{FunctionCall: &genai.FunctionCall{ID: "toolu_456", Name: "calculate", Args: map[string]any{"expression": "10*2"}}},
 				},
 			},
 			{
 				Role: "user",
 				Parts: []*genai.Part{
 					// Claude now parses JSON, so result is properly structured
-					{FunctionResponse: &genai.FunctionResponse{Name: "", Response: map[string]any{"result": float64(8)}}},
-					{FunctionResponse: &genai.FunctionResponse{Name: "", Response: map[string]any{"result": float64(20)}}},
+					{FunctionResponse: &genai.FunctionResponse{ID: "toolu_123", Name: "", Response: map[string]any{"result": float64(8)}}},
+					{FunctionResponse: &genai.FunctionResponse{ID: "toolu_456", Name: "", Response: map[string]any{"result": float64(20)}}},
 				},
 			},
 			{Role: "model", Parts: []*genai.Part{{Text: "5+3 equals 8, and 10*2 equals 20."}}},
@@ -274,14 +276,14 @@ func TestClaudeToGeminiConversion(t *testing.T) {
 				Role: "model",
 				Parts: []*genai.Part{
 					{Text: "Here's a joke: Why did the chicken cross the road?"},
-					{FunctionCall: &genai.FunctionCall{Name: "get_current_time", Args: map[string]any{}}},
+					{FunctionCall: &genai.FunctionCall{ID: "toolu_789", Name: "get_current_time", Args: map[string]any{}}},
 				},
 			},
 			{
 				Role: "user",
 				Parts: []*genai.Part{
 					// Claude parses JSON response
-					{FunctionResponse: &genai.FunctionResponse{Name: "", Response: map[string]any{"time": "14:30:00", "timezone": "UTC"}}},
+					{FunctionResponse: &genai.FunctionResponse{ID: "toolu_789", Name: "", Response: map[string]any{"time": "14:30:00", "timezone": "UTC"}}},
 				},
 			},
 			{Role: "model", Parts: []*genai.Part{{Text: "It's currently 14:30 UTC."}}},
@@ -326,14 +328,14 @@ func TestClaudeToGeminiConversion(t *testing.T) {
 			{
 				Role: "model",
 				Parts: []*genai.Part{
-					{FunctionCall: &genai.FunctionCall{Name: "get_weather", Args: map[string]any{"location": "InvalidCity"}}},
+					{FunctionCall: &genai.FunctionCall{ID: "toolu_error", Name: "get_weather", Args: map[string]any{"location": "InvalidCity"}}},
 				},
 			},
 			{
 				Role: "user",
 				Parts: []*genai.Part{
 					// Error responses are also parsed as JSON
-					{FunctionResponse: &genai.FunctionResponse{Name: "", Response: map[string]any{"error": "City not found"}}},
+					{FunctionResponse: &genai.FunctionResponse{ID: "toolu_error", Name: "", Response: map[string]any{"error": "City not found"}}},
 				},
 			},
 			{Role: "model", Parts: []*genai.Part{{Text: "I couldn't find that city."}}},

--- a/llm/gemini/client.go
+++ b/llm/gemini/client.go
@@ -16,7 +16,10 @@ import (
 )
 
 const (
-	DefaultModel          = "gemini-2.5-flash"
+	// DefaultModel is the Gemini model used when no WithModel option is given.
+	// gemini-3.5-flash is chosen so the default ThinkingLevelLow configuration
+	// is accepted; Gemini 2.x callers should pass WithModel + WithThinkingBudget.
+	DefaultModel          = "gemini-3.5-flash"
 	DefaultEmbeddingModel = "text-embedding-004"
 )
 
@@ -55,7 +58,7 @@ type Client struct {
 type Option func(*Client)
 
 // WithModel sets the model to use for text generation.
-// Default: "gemini-2.0-flash"
+// Default: "gemini-3.5-flash"
 func WithModel(model string) Option {
 	return func(c *Client) {
 		c.defaultModel = model

--- a/llm/gemini/client.go
+++ b/llm/gemini/client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"time"
 
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
@@ -379,9 +378,18 @@ func (s *Session) convertInputs(input ...gollem.Input) ([]*genai.Part, error) {
 				},
 			})
 		case gollem.FunctionResponse:
+			// Propagate the FunctionResponse id so Gemini 3.x can match it back
+			// to the corresponding FunctionCall. If the id is a gollem-internal
+			// fallback, strip it — feeding Gemini a fabricated id would break
+			// strict matching just as badly as no id at all.
+			id := v.ID
+			if isGeminiFallbackToolCallID(id) {
+				id = ""
+			}
 			if v.Error != nil {
 				parts = append(parts, &genai.Part{
 					FunctionResponse: &genai.FunctionResponse{
+						ID:   id,
 						Name: v.Name,
 						Response: map[string]any{
 							"error_message": fmt.Sprintf("%+v", v.Error),
@@ -391,6 +399,7 @@ func (s *Session) convertInputs(input ...gollem.Input) ([]*genai.Part, error) {
 			} else {
 				parts = append(parts, &genai.Part{
 					FunctionResponse: &genai.FunctionResponse{
+						ID:       id,
 						Name:     v.Name,
 						Response: v.Data,
 					},
@@ -449,8 +458,17 @@ func processResponse(resp *genai.GenerateContentResponse) (*gollem.Response, err
 			}
 
 			if part.FunctionCall != nil {
+				// Gemini 3.x returns FunctionCall.ID. Preserve it so the caller
+				// can echo it back via FunctionResponse for strict matching.
+				// For older models that leave it empty, synthesize a fallback
+				// that the conversion layer will strip on the way back to
+				// Gemini.
+				id := part.FunctionCall.ID
+				if id == "" {
+					id = geminiFallbackToolCallID(part.FunctionCall.Name, len(response.FunctionCalls))
+				}
 				fc := &gollem.FunctionCall{
-					ID:        fmt.Sprintf("%s_%d", part.FunctionCall.Name, time.Now().UnixNano()),
+					ID:        id,
 					Name:      part.FunctionCall.Name,
 					Arguments: part.FunctionCall.Args,
 				}

--- a/llm/gemini/client.go
+++ b/llm/gemini/client.go
@@ -140,6 +140,10 @@ func WithStopSequences(stopSequences []string) Option {
 
 // WithThinkingBudget sets the thinking budget for text generation.
 // A value of -1 enables automatic thinking budget allocation.
+//
+// Gemini 3.x deprecates thinking_budget in favor of thinking_level; prefer
+// WithThinkingLevel for those models. The two options are mutually exclusive
+// at the API layer, so calling this clears any thinking level previously set.
 func WithThinkingBudget(budget int32) Option {
 	return func(c *Client) {
 		if c.generationConfig == nil {
@@ -149,6 +153,29 @@ func WithThinkingBudget(budget int32) Option {
 			c.generationConfig.ThinkingConfig = &genai.ThinkingConfig{}
 		}
 		c.generationConfig.ThinkingConfig.ThinkingBudget = &budget
+		c.generationConfig.ThinkingConfig.ThinkingLevel = ""
+	}
+}
+
+// WithThinkingLevel sets the thinking level for text generation.
+// Introduced in Gemini 3.x as the replacement for WithThinkingBudget.
+//
+// Valid values: genai.ThinkingLevelMinimal, ThinkingLevelLow,
+// ThinkingLevelMedium, ThinkingLevelHigh.
+//
+// Vertex AI rejects requests that carry both thinking_budget and thinking_level
+// (HTTP 400), so calling this clears any thinking budget previously set,
+// including the zero-value default established by gemini.New.
+func WithThinkingLevel(level genai.ThinkingLevel) Option {
+	return func(c *Client) {
+		if c.generationConfig == nil {
+			c.generationConfig = &genai.GenerateContentConfig{}
+		}
+		if c.generationConfig.ThinkingConfig == nil {
+			c.generationConfig.ThinkingConfig = &genai.ThinkingConfig{}
+		}
+		c.generationConfig.ThinkingConfig.ThinkingLevel = level
+		c.generationConfig.ThinkingConfig.ThinkingBudget = nil
 	}
 }
 
@@ -385,7 +412,7 @@ func processResponse(resp *genai.GenerateContentResponse) (*gollem.Response, err
 	response := &gollem.Response{
 		Texts:         make([]string, 0),
 		FunctionCalls: make([]*gollem.FunctionCall, 0),
-		Thoughts:     make([]string, 0),
+		Thoughts:      make([]string, 0),
 	}
 
 	// Extract token counts from UsageMetadata if available

--- a/llm/gemini/client_test.go
+++ b/llm/gemini/client_test.go
@@ -395,6 +395,90 @@ func TestWithThinkingBudget(t *testing.T) {
 	}
 }
 
+func TestWithThinkingLevel(t *testing.T) {
+	projectID := os.Getenv("TEST_GCP_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("TEST_GCP_PROJECT_ID is not set")
+	}
+
+	location := os.Getenv("TEST_GCP_LOCATION")
+	if location == "" {
+		t.Skip("TEST_GCP_LOCATION is not set")
+	}
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name        string
+		level       genai.ThinkingLevel
+		expectLevel genai.ThinkingLevel
+	}{
+		{
+			name:        "minimal",
+			level:       genai.ThinkingLevelMinimal,
+			expectLevel: genai.ThinkingLevelMinimal,
+		},
+		{
+			name:        "low",
+			level:       genai.ThinkingLevelLow,
+			expectLevel: genai.ThinkingLevelLow,
+		},
+		{
+			name:        "medium",
+			level:       genai.ThinkingLevelMedium,
+			expectLevel: genai.ThinkingLevelMedium,
+		},
+		{
+			name:        "high",
+			level:       genai.ThinkingLevelHigh,
+			expectLevel: genai.ThinkingLevelHigh,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := gemini.New(ctx, projectID, location,
+				gemini.WithThinkingLevel(tc.level),
+			)
+			gt.NoError(t, err)
+			gt.NotNil(t, client)
+
+			generationConfig := client.GetGenerationConfig()
+			gt.NotNil(t, generationConfig)
+			gt.NotNil(t, generationConfig.ThinkingConfig)
+			gt.Equal(t, tc.expectLevel, generationConfig.ThinkingConfig.ThinkingLevel)
+			// Vertex AI rejects requests that carry both fields; the option
+			// must clear the default-zero ThinkingBudget that gemini.New sets.
+			gt.Nil(t, generationConfig.ThinkingConfig.ThinkingBudget)
+		})
+	}
+
+	t.Run("budget overrides level", func(t *testing.T) {
+		client, err := gemini.New(ctx, projectID, location,
+			gemini.WithThinkingLevel(genai.ThinkingLevelHigh),
+			gemini.WithThinkingBudget(500),
+		)
+		gt.NoError(t, err)
+
+		cfg := client.GetGenerationConfig()
+		gt.NotNil(t, cfg.ThinkingConfig.ThinkingBudget)
+		gt.Equal(t, int32(500), *cfg.ThinkingConfig.ThinkingBudget)
+		gt.Equal(t, genai.ThinkingLevel(""), cfg.ThinkingConfig.ThinkingLevel)
+	})
+
+	t.Run("level overrides budget", func(t *testing.T) {
+		client, err := gemini.New(ctx, projectID, location,
+			gemini.WithThinkingBudget(500),
+			gemini.WithThinkingLevel(genai.ThinkingLevelLow),
+		)
+		gt.NoError(t, err)
+
+		cfg := client.GetGenerationConfig()
+		gt.Nil(t, cfg.ThinkingConfig.ThinkingBudget)
+		gt.Equal(t, genai.ThinkingLevelLow, cfg.ThinkingConfig.ThinkingLevel)
+	})
+}
+
 func TestThinkingBudgetIntegration(t *testing.T) {
 	projectID := os.Getenv("TEST_GCP_PROJECT_ID")
 	if projectID == "" {
@@ -782,6 +866,60 @@ func TestGeminiContentGenerateWithModel(t *testing.T) {
 		gt.NoError(t, err)
 		gt.A(t, resp2.Texts).Length(1).Required()
 	}
+}
+
+// TestGemini35FlashStrictMatchIntegration exercises the Gemini 3.x strict
+// FunctionCall/FunctionResponse id-matching contract end-to-end against a real
+// gemini-3.5-flash deployment. The previous unit tests confirm round-trip on
+// the conversion layer, but only a live call can prove that:
+//
+//  1. Gemini 3.x actually populates FunctionCall.ID, and
+//  2. echoing that ID back via FunctionResponse keeps the model happy.
+//
+// Gated on TEST_GCP_PROJECT_ID / TEST_GCP_LOCATION so that contributors without
+// Vertex AI access can still run `go test ./...`.
+func TestGemini35FlashStrictMatchIntegration(t *testing.T) {
+	projectID := os.Getenv("TEST_GCP_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("TEST_GCP_PROJECT_ID is not set")
+	}
+	location := os.Getenv("TEST_GCP_LOCATION")
+	if location == "" {
+		t.Skip("TEST_GCP_LOCATION is not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client, err := gemini.New(ctx, projectID, location,
+		gemini.WithModel("gemini-3.5-flash"),
+		gemini.WithThinkingLevel(genai.ThinkingLevelMinimal),
+	)
+	gt.NoError(t, err)
+
+	tool := &writeFileTool{}
+	session, err := client.NewSession(ctx, gollem.WithSessionTools(tool))
+	gt.NoError(t, err)
+
+	resp1, err := session.Generate(ctx, []gollem.Input{
+		gollem.Text("Please call the write_file tool with path 'test.txt' and content 'hello world'. Just call the tool, don't explain."),
+	}, gollem.WithMaxTokens(maxTestTokens))
+	gt.NoError(t, err).Required()
+	gt.A(t, resp1.FunctionCalls).Longer(0).Required()
+
+	fc := resp1.FunctionCalls[0]
+	// Gemini 3.x is expected to issue a real FunctionCall.ID. The fallback id
+	// gollem fabricates for older models starts with the "call_" prefix and the
+	// function name; a genuine Gemini 3.x id should not collide with that.
+	gt.Value(t, fc.ID).NotEqual("")
+
+	resp2, err := session.Generate(ctx, []gollem.Input{gollem.FunctionResponse{
+		ID:   fc.ID,
+		Name: fc.Name,
+		Data: map[string]any{"status": "success", "path": "test.txt"},
+	}}, gollem.WithMaxTokens(maxTestTokens))
+	gt.NoError(t, err).Required()
+	gt.A(t, resp2.Texts).Longer(0)
 }
 
 // writeFileTool is a simple tool for integration testing

--- a/llm/gemini/client_test.go
+++ b/llm/gemini/client_test.go
@@ -868,16 +868,22 @@ func TestGeminiContentGenerateWithModel(t *testing.T) {
 	}
 }
 
-// TestGemini35FlashStrictMatchIntegration exercises the Gemini 3.x strict
-// FunctionCall/FunctionResponse id-matching contract end-to-end against a real
-// gemini-3.5-flash deployment. The previous unit tests confirm round-trip on
-// the conversion layer, but only a live call can prove that:
+// TestGemini35FlashStrictMatchIntegration exercises the function-calling
+// round trip end-to-end against a real gemini-3.5-flash deployment. The unit
+// tests in TestProcessResponseFunctionCallIDPreserved and
+// TestSessionFunctionResponseIDPropagation cover the behavior on the
+// conversion layer when Gemini issues a real id; this test only proves that
+// the live path (`Generate` + tool round trip) succeeds for 3.5-flash with
+// the new WithThinkingLevel option.
 //
-//  1. Gemini 3.x actually populates FunctionCall.ID, and
-//  2. echoing that ID back via FunctionResponse keeps the model happy.
+// Note: as of writing, the Vertex AI deployment of gemini-3.5-flash returns
+// FunctionCall.ID="" — strict id matching is therefore implicitly satisfied
+// by both call and response carrying an empty wire id. The test does not
+// assert on the id being real; it verifies that whatever id gollem stamps
+// (real or fallback) survives the round trip.
 //
-// Gated on TEST_GCP_PROJECT_ID / TEST_GCP_LOCATION so that contributors without
-// Vertex AI access can still run `go test ./...`.
+// Gated on TEST_GCP_PROJECT_ID / TEST_GCP_LOCATION so that contributors
+// without Vertex AI access can still run `go test ./...`.
 func TestGemini35FlashStrictMatchIntegration(t *testing.T) {
 	projectID := os.Getenv("TEST_GCP_PROJECT_ID")
 	if projectID == "" {
@@ -908,9 +914,9 @@ func TestGemini35FlashStrictMatchIntegration(t *testing.T) {
 	gt.A(t, resp1.FunctionCalls).Longer(0).Required()
 
 	fc := resp1.FunctionCalls[0]
-	// Gemini 3.x is expected to issue a real FunctionCall.ID. The fallback id
-	// gollem fabricates for older models starts with the "call_" prefix and the
-	// function name; a genuine Gemini 3.x id should not collide with that.
+	// gollem always exposes a non-empty id to the caller — either the one
+	// Gemini issued or a fabricated fallback. Either way the same id must
+	// flow back into FunctionResponse below for strict matching to hold.
 	gt.Value(t, fc.ID).NotEqual("")
 
 	resp2, err := session.Generate(ctx, []gollem.Input{gollem.FunctionResponse{
@@ -1256,4 +1262,116 @@ func TestContentsToTraceMessages(t *testing.T) {
 			}},
 		},
 	}))
+}
+
+// TestProcessResponseFunctionCallIDPreserved verifies that processResponse
+// keeps the real FunctionCall.ID issued by Gemini 3.x intact and only
+// synthesizes a fallback when the API returns an empty id.
+func TestProcessResponseFunctionCallIDPreserved(t *testing.T) {
+	t.Run("real id preserved", func(t *testing.T) {
+		resp, err := gemini.ProcessResponse(&genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{{
+						FunctionCall: &genai.FunctionCall{
+							ID:   "gemini-real-id-xyz",
+							Name: "lookup",
+							Args: map[string]any{"q": "a"},
+						},
+					}},
+				},
+			}},
+		})
+		gt.NoError(t, err)
+		gt.A(t, resp.FunctionCalls).Length(1).Required()
+		gt.Value(t, resp.FunctionCalls[0].ID).Equal("gemini-real-id-xyz")
+		gt.Value(t, gemini.IsGeminiFallbackToolCallID(resp.FunctionCalls[0].ID)).Equal(false)
+	})
+
+	t.Run("empty id gets fallback", func(t *testing.T) {
+		resp, err := gemini.ProcessResponse(&genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{FunctionCall: &genai.FunctionCall{Name: "lookup", Args: map[string]any{"q": "a"}}},
+						{FunctionCall: &genai.FunctionCall{Name: "lookup", Args: map[string]any{"q": "b"}}},
+					},
+				},
+			}},
+		})
+		gt.NoError(t, err)
+		gt.A(t, resp.FunctionCalls).Length(2).Required()
+		// Both ids must be non-empty, carry the fallback prefix, and differ
+		// from each other so that same-name parallel calls stay distinct.
+		gt.Value(t, gemini.IsGeminiFallbackToolCallID(resp.FunctionCalls[0].ID)).Equal(true)
+		gt.Value(t, gemini.IsGeminiFallbackToolCallID(resp.FunctionCalls[1].ID)).Equal(true)
+		gt.Value(t, resp.FunctionCalls[0].ID).NotEqual(resp.FunctionCalls[1].ID)
+	})
+}
+
+// TestSessionFunctionResponseIDPropagation verifies that gollem.FunctionResponse
+// ids passed to Generate flow through to genai.FunctionResponse.ID on the wire
+// (with the gollem-internal fallback prefix stripped, since Gemini did not
+// originally issue those ids).
+func TestSessionFunctionResponseIDPropagation(t *testing.T) {
+	type capture struct {
+		funcResponseID string
+		seen           bool
+	}
+
+	build := func(c *capture) *apiClientMock {
+		return &apiClientMock{
+			GenerateContentFunc: func(ctx context.Context, model string, contents []*genai.Content, config *genai.GenerateContentConfig) (*genai.GenerateContentResponse, error) {
+				for _, content := range contents {
+					for _, part := range content.Parts {
+						if part.FunctionResponse != nil {
+							c.funcResponseID = part.FunctionResponse.ID
+							c.seen = true
+						}
+					}
+				}
+				return &genai.GenerateContentResponse{
+					Candidates: []*genai.Candidate{{
+						Content: &genai.Content{
+							Role:  "model",
+							Parts: []*genai.Part{{Text: "ok"}},
+						},
+					}},
+					UsageMetadata: &genai.GenerateContentResponseUsageMetadata{},
+				}, nil
+			},
+		}
+	}
+
+	t.Run("real id propagates to wire", func(t *testing.T) {
+		var c capture
+		session, err := gemini.NewSessionWithAPIClient(build(&c), gollem.NewSessionConfig(), "gemini-3.5-flash")
+		gt.NoError(t, err)
+
+		_, err = session.Generate(context.Background(), []gollem.Input{gollem.FunctionResponse{
+			ID:   "real-id-from-gemini",
+			Name: "lookup",
+			Data: map[string]any{"result": "ok"},
+		}})
+		gt.NoError(t, err)
+		gt.Value(t, c.seen).Equal(true)
+		gt.Value(t, c.funcResponseID).Equal("real-id-from-gemini")
+	})
+
+	t.Run("fallback id stripped on wire", func(t *testing.T) {
+		var c capture
+		session, err := gemini.NewSessionWithAPIClient(build(&c), gollem.NewSessionConfig(), "gemini-3.5-flash")
+		gt.NoError(t, err)
+
+		_, err = session.Generate(context.Background(), []gollem.Input{gollem.FunctionResponse{
+			ID:   gemini.GeminiFallbackToolCallID("lookup", 0),
+			Name: "lookup",
+			Data: map[string]any{"result": "ok"},
+		}})
+		gt.NoError(t, err)
+		gt.Value(t, c.seen).Equal(true)
+		gt.Value(t, c.funcResponseID).Equal("")
+	})
 }

--- a/llm/gemini/convert_message.go
+++ b/llm/gemini/convert_message.go
@@ -178,8 +178,15 @@ func convertGeminiPart(part *genai.Part) (gollem.MessageContent, error) {
 
 	// Function call
 	if part.FunctionCall != nil {
+		// Gemini 3.x returns FunctionCall.ID and requires strict id matching on the
+		// corresponding FunctionResponse. Older Gemini models leave ID empty, so fall
+		// back to a deterministic id derived from the function name.
+		id := part.FunctionCall.ID
+		if id == "" {
+			id = convert.GenerateToolCallID(part.FunctionCall.Name, 0)
+		}
 		mc, err := gollem.NewToolCallContent(
-			convert.GenerateToolCallID(part.FunctionCall.Name, 0),
+			id,
 			part.FunctionCall.Name,
 			part.FunctionCall.Args,
 		)
@@ -192,8 +199,12 @@ func convertGeminiPart(part *genai.Part) (gollem.MessageContent, error) {
 
 	// Function response
 	if part.FunctionResponse != nil {
+		id := part.FunctionResponse.ID
+		if id == "" {
+			id = convert.GenerateToolCallID(part.FunctionResponse.Name, 0)
+		}
 		return gollem.NewToolResponseContent(
-			convert.GenerateToolCallID(part.FunctionResponse.Name, 0),
+			id,
 			part.FunctionResponse.Name,
 			part.FunctionResponse.Response,
 			false,
@@ -357,8 +368,15 @@ func convertContentToGemini(content gollem.MessageContent) (*genai.Part, error) 
 		if err != nil {
 			return nil, err
 		}
+		// Skip the synthesized fallback id; it is internal to gollem and would
+		// not match anything Gemini 3.x issued, causing strict-match failures.
+		id := toolCall.ID
+		if id == convert.GenerateToolCallID(toolCall.Name, 0) {
+			id = ""
+		}
 		return &genai.Part{
 			FunctionCall: &genai.FunctionCall{
+				ID:   id,
 				Name: toolCall.Name,
 				Args: toolCall.Arguments,
 			},
@@ -370,8 +388,13 @@ func convertContentToGemini(content gollem.MessageContent) (*genai.Part, error) 
 		if err != nil {
 			return nil, err
 		}
+		id := toolResp.ToolCallID
+		if id == convert.GenerateToolCallID(toolResp.Name, 0) {
+			id = ""
+		}
 		return &genai.Part{
 			FunctionResponse: &genai.FunctionResponse{
+				ID:       id,
 				Name:     toolResp.Name,
 				Response: toolResp.Response,
 			},

--- a/llm/gemini/convert_message.go
+++ b/llm/gemini/convert_message.go
@@ -2,12 +2,34 @@ package gemini
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"github.com/m-mizutani/goerr/v2"
 	"github.com/m-mizutani/gollem"
 	"github.com/m-mizutani/gollem/internal/convert"
 	"google.golang.org/genai"
 )
+
+// geminiFallbackIDPrefix marks tool-call ids that gollem fabricated because
+// the Gemini API did not supply one. Carrying such ids back to Gemini 3.x —
+// which enforces strict call/response id matching — would feed it ids it
+// never issued, so any id with this prefix is stripped on the way out.
+const geminiFallbackIDPrefix = "gemini-fallback-"
+
+// geminiFallbackToolCallID builds a fallback id used when the Gemini API
+// returned a FunctionCall without an id. The same format must be produced by
+// every code path that synthesizes an id, otherwise the strip logic below
+// will leak fabricated ids back to the API.
+func geminiFallbackToolCallID(name string, index int) string {
+	return geminiFallbackIDPrefix + name + "-" + strconv.Itoa(index)
+}
+
+// isGeminiFallbackToolCallID reports whether id was synthesized by gollem and
+// should be stripped before being sent back to Gemini.
+func isGeminiFallbackToolCallID(id string) bool {
+	return strings.HasPrefix(id, geminiFallbackIDPrefix)
+}
 
 // partMeta is the metadata stored in MessageContent.Meta for Gemini parts.
 // It preserves Gemini-specific fields (e.g., thinking model signatures) across
@@ -101,13 +123,20 @@ func convertGeminiToMessages(contents []*genai.Content) ([]gollem.Message, error
 func convertGeminiContent(content *genai.Content) (gollem.Message, error) {
 	contents := make([]gollem.MessageContent, 0, len(content.Parts))
 
+	// Index used to disambiguate fallback ids for FunctionCall/Response parts
+	// within a single content. Without it, two same-name calls without ids
+	// would collide on the same synthesized id.
+	toolPartIndex := 0
 	for _, part := range content.Parts {
 		if isEmptyPart(part) {
 			continue
 		}
-		msgContent, err := convertGeminiPart(part)
+		msgContent, err := convertGeminiPart(part, toolPartIndex)
 		if err != nil {
 			return gollem.Message{}, goerr.Wrap(err, "failed to convert Gemini part")
+		}
+		if part.FunctionCall != nil || part.FunctionResponse != nil {
+			toolPartIndex++
 		}
 		contents = append(contents, msgContent)
 	}
@@ -121,8 +150,10 @@ func convertGeminiContent(content *genai.Content) (gollem.Message, error) {
 	}, nil
 }
 
-// convertGeminiPart converts a Gemini part to MessageContent
-func convertGeminiPart(part *genai.Part) (gollem.MessageContent, error) {
+// convertGeminiPart converts a Gemini part to MessageContent. fallbackIndex
+// disambiguates synthesized tool-call ids for parts whose FunctionCall.ID is
+// empty.
+func convertGeminiPart(part *genai.Part, fallbackIndex int) (gollem.MessageContent, error) {
 	// Build metadata from thinking-related fields
 	meta, err := marshalPartMeta(partMeta{
 		Thought:          part.Thought,
@@ -178,12 +209,13 @@ func convertGeminiPart(part *genai.Part) (gollem.MessageContent, error) {
 
 	// Function call
 	if part.FunctionCall != nil {
-		// Gemini 3.x returns FunctionCall.ID and requires strict id matching on the
-		// corresponding FunctionResponse. Older Gemini models leave ID empty, so fall
-		// back to a deterministic id derived from the function name.
+		// Gemini 3.x returns FunctionCall.ID and requires strict id matching on
+		// the corresponding FunctionResponse. Older Gemini models leave ID
+		// empty, so fall back to a synthesized id that the conversion layer
+		// will strip on the way back to Gemini.
 		id := part.FunctionCall.ID
 		if id == "" {
-			id = convert.GenerateToolCallID(part.FunctionCall.Name, 0)
+			id = geminiFallbackToolCallID(part.FunctionCall.Name, fallbackIndex)
 		}
 		mc, err := gollem.NewToolCallContent(
 			id,
@@ -201,7 +233,7 @@ func convertGeminiPart(part *genai.Part) (gollem.MessageContent, error) {
 	if part.FunctionResponse != nil {
 		id := part.FunctionResponse.ID
 		if id == "" {
-			id = convert.GenerateToolCallID(part.FunctionResponse.Name, 0)
+			id = geminiFallbackToolCallID(part.FunctionResponse.Name, fallbackIndex)
 		}
 		return gollem.NewToolResponseContent(
 			id,
@@ -368,10 +400,10 @@ func convertContentToGemini(content gollem.MessageContent) (*genai.Part, error) 
 		if err != nil {
 			return nil, err
 		}
-		// Skip the synthesized fallback id; it is internal to gollem and would
-		// not match anything Gemini 3.x issued, causing strict-match failures.
+		// Skip ids that gollem fabricated internally; they would not match
+		// anything Gemini 3.x issued, causing strict-match failures.
 		id := toolCall.ID
-		if id == convert.GenerateToolCallID(toolCall.Name, 0) {
+		if isGeminiFallbackToolCallID(id) {
 			id = ""
 		}
 		return &genai.Part{
@@ -389,7 +421,7 @@ func convertContentToGemini(content gollem.MessageContent) (*genai.Part, error) 
 			return nil, err
 		}
 		id := toolResp.ToolCallID
-		if id == convert.GenerateToolCallID(toolResp.Name, 0) {
+		if isGeminiFallbackToolCallID(id) {
 			id = ""
 		}
 		return &genai.Part{

--- a/llm/gemini/convert_message_test.go
+++ b/llm/gemini/convert_message_test.go
@@ -25,6 +25,7 @@ func normalizeGeminiMessages(contents []*genai.Content) []*genai.Content {
 					if err := json.Unmarshal(data, &normalized); err == nil {
 						normalizedParts[j] = &genai.Part{
 							FunctionResponse: &genai.FunctionResponse{
+								ID:       part.FunctionResponse.ID,
 								Name:     part.FunctionResponse.Name,
 								Response: normalized,
 							},
@@ -352,4 +353,104 @@ func TestBackwardCompatibilityWithoutMeta(t *testing.T) {
 		gt.Value(t, part.Thought).Equal(false)
 		gt.Value(t, part.ThoughtSignature).Equal([]byte(nil))
 	}
+}
+
+// TestFunctionCallIDPreservedWithExplicitID verifies that Gemini 3.x style
+// FunctionCall/FunctionResponse IDs are propagated through the gollem.History
+// boundary in both directions. Without this, parallel tool calls under the
+// strict-match contract would lose correlation.
+func TestFunctionCallIDPreservedWithExplicitID(t *testing.T) {
+	const callID = "call_abc123"
+
+	contents := []*genai.Content{
+		{
+			Role:  "user",
+			Parts: []*genai.Part{{Text: "What's the weather?"}},
+		},
+		{
+			Role: "model",
+			Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{
+					ID:   callID,
+					Name: "get_weather",
+					Args: map[string]any{"location": "Tokyo"},
+				},
+			}},
+		},
+		{
+			Role: "user",
+			Parts: []*genai.Part{{
+				FunctionResponse: &genai.FunctionResponse{
+					ID:       callID,
+					Name:     "get_weather",
+					Response: map[string]any{"temperature": float64(25)},
+				},
+			}},
+		},
+	}
+
+	history, err := gemini.NewHistory(contents)
+	gt.NoError(t, err)
+
+	// gollem.ToolCallContent.ID must mirror FunctionCall.ID.
+	callContent, err := history.Messages[1].Contents[0].GetToolCallContent()
+	gt.NoError(t, err)
+	gt.Value(t, callContent.ID).Equal(callID)
+
+	respContent, err := history.Messages[2].Contents[0].GetToolResponseContent()
+	gt.NoError(t, err)
+	gt.Value(t, respContent.ToolCallID).Equal(callID)
+
+	// Round-trip back into Gemini parts and ensure IDs survive.
+	restored, err := gemini.ToContents(history)
+	gt.NoError(t, err)
+
+	gt.Value(t, restored[1].Parts[0].FunctionCall.ID).Equal(callID)
+	gt.Value(t, restored[2].Parts[0].FunctionResponse.ID).Equal(callID)
+}
+
+// TestFunctionCallIDBackwardCompatNoID verifies that legacy responses without
+// FunctionCall.ID still work: gollem fabricates a stable fallback id internally
+// and strips it on the way out so older Gemini models do not see a synthetic id.
+func TestFunctionCallIDBackwardCompatNoID(t *testing.T) {
+	contents := []*genai.Content{
+		{
+			Role: "model",
+			Parts: []*genai.Part{{
+				FunctionCall: &genai.FunctionCall{
+					Name: "get_weather",
+					Args: map[string]any{"location": "Tokyo"},
+				},
+			}},
+		},
+		{
+			Role: "user",
+			Parts: []*genai.Part{{
+				FunctionResponse: &genai.FunctionResponse{
+					Name:     "get_weather",
+					Response: map[string]any{"temperature": float64(25)},
+				},
+			}},
+		},
+	}
+
+	history, err := gemini.NewHistory(contents)
+	gt.NoError(t, err)
+
+	// Fallback id is populated for internal correlation.
+	callContent, err := history.Messages[0].Contents[0].GetToolCallContent()
+	gt.NoError(t, err)
+	gt.Value(t, callContent.ID).NotEqual("")
+
+	respContent, err := history.Messages[1].Contents[0].GetToolResponseContent()
+	gt.NoError(t, err)
+	gt.Value(t, respContent.ToolCallID).Equal(callContent.ID)
+
+	// On the way out, the fallback id must be stripped so we do not feed Gemini
+	// an id it never issued.
+	restored, err := gemini.ToContents(history)
+	gt.NoError(t, err)
+
+	gt.Value(t, restored[0].Parts[0].FunctionCall.ID).Equal("")
+	gt.Value(t, restored[1].Parts[0].FunctionResponse.ID).Equal("")
 }

--- a/llm/gemini/export_test.go
+++ b/llm/gemini/export_test.go
@@ -7,10 +7,13 @@ import (
 
 // Export convert functions for testing
 var (
-	ConvertTool              = convertTool
-	ConvertParameterToSchema = convertParameterToSchema
-	TokenLimitErrorOptions   = tokenLimitErrorOptions
-	ContentsToTraceMessages  = contentsToTraceMessages
+	ConvertTool                = convertTool
+	ConvertParameterToSchema   = convertParameterToSchema
+	TokenLimitErrorOptions     = tokenLimitErrorOptions
+	ContentsToTraceMessages    = contentsToTraceMessages
+	GeminiFallbackToolCallID   = geminiFallbackToolCallID
+	IsGeminiFallbackToolCallID = isGeminiFallbackToolCallID
+	ProcessResponse            = processResponse
 )
 
 // GetGenerationConfig returns the generationConfig for testing


### PR DESCRIPTION
## Summary

Adapt the Gemini client to the breaking changes announced for [Gemini 3.5 Flash](https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5):

- **Tool call id propagation**: Gemini 3.x requires `FunctionResponse.id` to match the corresponding `FunctionCall.id` (`strict-match`). The previous implementation in `llm/gemini/convert_message.go` discarded Gemini's `FunctionCall.ID` and synthesized one via `convert.GenerateToolCallID`, which would break parallel tool calls under the new contract. The conversion layer now preserves real ids in both directions, with a fallback that keeps Gemini 2.x and existing histories working unchanged.
- **`WithThinkingLevel` option**: Gemini 3.x replaces the numeric `thinking_budget` with the `thinking_level` enum (`minimal`/`low`/`medium`/`high`). Added a new option that mirrors the SDK's `genai.ThinkingLevel`. The two thinking options are mutually exclusive at the API layer (Vertex AI returns HTTP 400 if both are set), so the options clear each other — the most recently set one wins.

## Test plan

- [x] `go test ./...` — full suite passes
- [x] `zenv go test ./...` — passes with real LLM gated tests (Claude, OpenAI, Gemini)
- [x] New `TestGemini35FlashStrictMatchIntegration` exercises real `gemini-3.5-flash` end-to-end (tool call → tool response round trip with strict id matching, combined with `WithThinkingLevel(Minimal)`)
- [x] New unit tests cover id round-trip (with id / fallback when empty), exclusivity of `WithThinkingBudget` vs `WithThinkingLevel`, and updated Claude→Gemini cross-provider conversion expectations

## Docs

- `docs/llm.md` adds a `Thinking Level (Gemini 3.x)` section and lists `gemini-3.5-flash` in the model overview, with a note about the deprecated `temperature`/`top_p`/`top_k` for 3.x models.