### PR TITLE
ci: add cicd-sensor runtime monitoring to all workflows

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -15,6 +15,8 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout Source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Run Gosec Security Scanner

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -8,6 +8,8 @@ jobs:
     name: invisible unicode chars
     runs-on: ubuntu-latest
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install ripgrep

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
       security-events: write
     runs-on: ubuntu-latest
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout upstream repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,6 +15,8 @@ jobs:
       contents: read
 
     steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@6ee257338e68af2b279b321b3346fe5f385aa498 # v0.0.29
       - name: Checkout upstream repo
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Summary
- Add [`cicd-sensor/cicd-sensor-action@v0.0.29`](https://github.com/cicd-sensor/cicd-sensor-action) as the first step in every GitHub Actions workflow (`gosec`, `integrity`, `lint`, `test`, `trivy`)
- cicd-sensor is an eBPF-powered runtime sensor that watches process ancestry inside the runner to detect supply-chain attacks against CI jobs
- Action is pinned to commit SHA `6ee257338e68af2b279b321b3346fe5f385aa498` (v0.0.29) to comply with the repo's "pin third-party actions to a SHA" practice

## Notes
- Per the action's docs, the sensor must run as the first step so it can observe subsequent steps' process trees. All five workflows are updated accordingly.
- Runners stay on `ubuntu-latest` (currently 24.04, satisfies the kernel 5.15+ requirement on amd64).
- No new secrets or permissions are required for the default (manager-less) mode. If a manager is introduced later, `manager-url` / `manager-token` inputs can be added per workflow.

## Test plan
- [ ] Confirm each workflow's first step is `cicd-sensor` and it succeeds on this PR's CI run
- [ ] Confirm downstream steps (gosec / trivy / golangci-lint / go test / invisible-chars) still complete as before
- [ ] Spot-check the cicd-sensor HTML report / attestation artifact appears on at least one workflow run