### PR TITLE
feat: type-safe tool definitions via NewTool[In, Out]

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -416,6 +416,24 @@ var userSchema = gollem.MustToSchema(UserProfile{})
 // Panics if conversion fails
 ```
 
+### ToolSchema / MustToolSchema
+
+`ToSchema` converts a single Go value into a schema. When defining a **tool**, use
+`ToolSchema[In, Out]()` instead: it infers the input schema from the `In` type and
+also verifies that the `Out` type can form a valid tool result (a JSON object).
+
+```go
+// Returns the input parameter schema; errors if In/Out are not valid tool types.
+schema, err := gollem.ToolSchema[AddArgs, AddResult]()
+
+// Panics on error — useful as a startup assertion of a tool's In/Out types.
+schema := gollem.MustToolSchema[AddArgs, AddResult]()
+```
+
+These power [`NewTool` / `MustNewTool`](tools.md#type-safe-tools-with-newtool), which
+build a `Tool` directly from typed handlers. `Out` has no slot in `ToolSpec`, so it is
+validated (not returned) to ensure the handler's result is convertible to the wire form.
+
 ### Complete Example
 
 See [examples/json_schema](../examples/json_schema) for a complete working example.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -39,6 +39,65 @@ func (t *HelloTool) Run(ctx context.Context, args map[string]any) (map[string]an
 }
 ```
 
+## Type-safe Tools with `NewTool`
+
+Implementing `Tool` by hand means writing the `Spec()` parameter map and then
+asserting each argument's type inside `Run` (`args["name"].(string)`). Those two
+places can drift apart, and a wrong assertion panics at runtime.
+
+`NewTool[In, Out]` removes both problems. The input schema is inferred from the
+`In` type (using the same struct tags as [`ToSchema`](schema.md#supported-struct-tags)),
+and your handler receives a decoded `In` value instead of a raw map:
+
+```go
+type greetArgs struct {
+    Name string `json:"name" description:"Name of the person to greet" required:"true"`
+}
+
+type greetResult struct {
+    Message string `json:"message"`
+}
+
+tool, err := gollem.NewTool("hello", "Returns a greeting",
+    func(ctx context.Context, in greetArgs) (greetResult, error) {
+        return greetResult{Message: fmt.Sprintf("Hello, %s!", in.Name)}, nil
+    })
+if err != nil {
+    return err
+}
+```
+
+- `In` must be a **struct**. The handler argument is fully typed — no assertions,
+  no panics. (A map is rejected: it would produce a property-less schema that tells
+  the LLM nothing about the arguments, while giving none of the type safety.)
+- `Out` must encode to a JSON object (a struct, or `map[string]any`). A
+  `map[string]any` result is passed through unchanged, so existing tools can adopt
+  `NewTool` incrementally by keeping their map output.
+- **By default**, argument validation against the inferred schema runs automatically
+  before the handler (see [Using Tools](#using-tools)), and the typed decode is the
+  safety net behind it. If you disable it with `WithDisableArgsValidation`, only the
+  typed decode remains: it enforces field *types*, but not `required`/`enum`/`min`/`max`,
+  so a missing field arrives as its zero value.
+
+`NewTool` returns an error when `In`/`Out` cannot form a valid schema (for example
+a malformed struct tag, or a scalar type). For static registration, use
+`MustNewTool`, which panics instead — convenient inside a slice literal:
+
+```go
+agent := gollem.New(client, gollem.WithTools(
+    gollem.MustNewTool("hello", "Returns a greeting", greet),
+    gollem.MustNewTool("add", "Adds two numbers", add),
+))
+```
+
+To validate a tool's `In`/`Out` types without constructing the tool (for example in
+a test), use `ToolSchema[In, Out]()` (returns an error) or `MustToolSchema[In, Out]()`
+(panics). Both reuse the same inference, so they agree with what `NewTool` produces.
+
+> [!NOTE]
+> `ToolSchema` (tool input/output check) is distinct from `ToSchema` (single
+> struct → schema). See [schema.md](schema.md#creating-schemas-from-go-structs).
+
 ## Tool Specification
 
 The `ToolSpec` defines the tool's interface:

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,9 @@ var (
 	// ErrInvalidInputSchema is returned when the input schema from MCP is invalid or unsupported.
 	ErrInvalidInputSchema = errors.New("invalid input schema")
 
+	// ErrInvalidToolType is returned when a typed tool's In/Out type parameter cannot form a valid schema.
+	ErrInvalidToolType = errors.New("invalid tool type")
+
 	// ErrInvalidHistoryData is returned when the history data is invalid or unsupported.
 	ErrInvalidHistoryData = errors.New("invalid history data")
 

--- a/examples/tools/main.go
+++ b/examples/tools/main.go
@@ -20,10 +20,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Register tools
+	// Register tools defined with typed handlers. The schema is inferred from the
+	// input struct and the handler receives a decoded value, so there is no manual
+	// type assertion on a map[string]any.
 	tools := []gollem.Tool{
-		&AddTool{},
-		&MultiplyTool{},
+		gollem.MustNewTool("add", "Adds two numbers together", add),
+		gollem.MustNewTool("multiply", "Multiplies two numbers together", multiply),
 	}
 
 	// Create agent with tools
@@ -53,69 +55,32 @@ func main() {
 	log.Printf("📝 Query: %s", query)
 
 	// Execute with automatic session management
-	if err := agent.Execute(ctx, query); err != nil {
+	if _, err := agent.Execute(ctx, gollem.Text(query)); err != nil {
 		log.Fatal(err)
 	}
 
 	log.Printf("✅ Calculation completed!")
 }
 
-// AddTool is a tool that adds two numbers
-type AddTool struct{}
-
-func (t *AddTool) Run(ctx context.Context, args map[string]any) (map[string]any, error) {
-	a := args["a"].(float64)
-	b := args["b"].(float64)
-	result := a + b
-	log.Printf("🔢 Add: %.2f + %.2f = %.2f", a, b, result)
-	return map[string]any{"result": result}, nil
+// operands is the typed input shared by the calculator tools.
+type operands struct {
+	A float64 `json:"a" description:"First number" required:"true"`
+	B float64 `json:"b" description:"Second number" required:"true"`
 }
 
-func (t *AddTool) Spec() gollem.ToolSpec {
-	return gollem.ToolSpec{
-		Name:        "add",
-		Description: "Adds two numbers together",
-		Parameters: map[string]*gollem.Parameter{
-			"a": {
-				Type:        gollem.TypeNumber,
-				Description: "First number",
-				Required:    true,
-			},
-			"b": {
-				Type:        gollem.TypeNumber,
-				Description: "Second number",
-				Required:    true,
-			},
-		},
-	}
+// calcResult is the typed output of the calculator tools.
+type calcResult struct {
+	Result float64 `json:"result" description:"Calculation result"`
 }
 
-// MultiplyTool is a tool that multiplies two numbers
-type MultiplyTool struct{}
-
-func (t *MultiplyTool) Run(ctx context.Context, args map[string]any) (map[string]any, error) {
-	a := args["a"].(float64)
-	b := args["b"].(float64)
-	result := a * b
-	log.Printf("🔢 Multiply: %.2f × %.2f = %.2f", a, b, result)
-	return map[string]any{"result": result}, nil
+func add(_ context.Context, in operands) (calcResult, error) {
+	result := in.A + in.B
+	log.Printf("🔢 Add: %.2f + %.2f = %.2f", in.A, in.B, result)
+	return calcResult{Result: result}, nil
 }
 
-func (t *MultiplyTool) Spec() gollem.ToolSpec {
-	return gollem.ToolSpec{
-		Name:        "multiply",
-		Description: "Multiplies two numbers together",
-		Parameters: map[string]*gollem.Parameter{
-			"a": {
-				Type:        gollem.TypeNumber,
-				Description: "First number",
-				Required:    true,
-			},
-			"b": {
-				Type:        gollem.TypeNumber,
-				Description: "Second number",
-				Required:    true,
-			},
-		},
-	}
+func multiply(_ context.Context, in operands) (calcResult, error) {
+	result := in.A * in.B
+	log.Printf("🔢 Multiply: %.2f × %.2f = %.2f", in.A, in.B, result)
+	return calcResult{Result: result}, nil
 }

--- a/typed_tool.go
+++ b/typed_tool.go
@@ -1,0 +1,192 @@
+package gollem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/m-mizutani/goerr/v2"
+)
+
+// NewTool creates a Tool from a typed handler. The input schema is inferred from
+// the In type via ToSchema (so the same struct tags as Query[T] apply), and the
+// handler receives a decoded In value instead of a raw map[string]any, removing
+// the need for manual type assertions in Run.
+//
+// In must be a struct (its schema is a JSON "object" with declared properties).
+// A map is rejected: it would yield a property-less schema that gives the LLM no
+// argument information while providing none of the type safety this API exists for.
+// Out must be a struct or map (it must encode to a JSON object); see toResultMap.
+// If either type is unfit, an error is returned rather than a panic, so callers
+// decide how to handle a malformed definition. Use MustNewTool for static
+// registration where a panic is preferred.
+func NewTool[In, Out any](
+	name, description string,
+	run func(ctx context.Context, in In) (Out, error),
+) (Tool, error) {
+	schema, err := buildToolSchema[In, Out]()
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to build tool", goerr.V("tool", name))
+	}
+
+	tool := &typedTool[In, Out]{
+		name:        name,
+		description: description,
+		params:      schema.Properties,
+		run:         run,
+	}
+
+	// Validate the resulting spec so that an empty name or otherwise invalid
+	// definition is reported at construction time rather than at call time.
+	spec := tool.Spec()
+	if err := spec.Validate(); err != nil {
+		return nil, goerr.Wrap(err, "invalid tool spec", goerr.V("tool", name))
+	}
+
+	return tool, nil
+}
+
+// MustNewTool is like NewTool but panics on error. It is intended for static
+// initialization (e.g. package-level variables or slice literals passed to
+// WithTools), where a malformed In/Out type is a programming error that should
+// surface immediately. It follows the same convention as MustToSchema.
+func MustNewTool[In, Out any](
+	name, description string,
+	run func(ctx context.Context, in In) (Out, error),
+) Tool {
+	tool, err := NewTool(name, description, run)
+	if err != nil {
+		panic(goerr.Wrap(err, "MustNewTool failed", goerr.V("tool", name)))
+	}
+	return tool
+}
+
+// ToolSchema builds the input parameter schema for a typed tool from the In type
+// and validates that both In and Out can form a valid tool schema. The returned
+// Parameter is the input object schema (TypeObject). Out is only validated — not
+// returned — because ToolSpec has no output schema slot; the check ensures the
+// handler's result can be converted to the wire map[string]any form.
+func ToolSchema[In, Out any]() (*Parameter, error) {
+	return buildToolSchema[In, Out]()
+}
+
+// MustToolSchema is like ToolSchema but panics on error, mirroring the
+// ToSchema / MustToSchema pair. It is useful as a startup assertion of a typed
+// tool's In/Out types.
+func MustToolSchema[In, Out any]() *Parameter {
+	schema, err := ToolSchema[In, Out]()
+	if err != nil {
+		panic(goerr.Wrap(err, "MustToolSchema failed"))
+	}
+	return schema
+}
+
+// typedTool adapts a typed handler func(ctx, In) (Out, error) to the Tool
+// interface by inferring the schema from In and bridging args/result via JSON.
+type typedTool[In, Out any] struct {
+	name        string
+	description string
+	params      map[string]*Parameter
+	run         func(ctx context.Context, in In) (Out, error)
+}
+
+func (t *typedTool[In, Out]) Spec() ToolSpec {
+	return ToolSpec{
+		Name:        t.name,
+		Description: t.description,
+		Parameters:  t.params,
+	}
+}
+
+func (t *typedTool[In, Out]) Run(ctx context.Context, args map[string]any) (map[string]any, error) {
+	// Bridge the untyped args into the typed In via a JSON round-trip. This uses
+	// the same json tags that ToSchema reads for the schema, so field naming
+	// cannot drift between the schema and the decode. Argument validation against
+	// the schema already runs before Run (see executeToolCall); this decode is the
+	// type-level safety net behind it.
+	var in In
+	raw, err := json.Marshal(args)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to encode tool arguments", goerr.V("tool", t.name))
+	}
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return nil, goerr.Wrap(err, "failed to decode tool arguments", goerr.V("tool", t.name))
+	}
+
+	out, err := t.run(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	return toResultMap(out)
+}
+
+// buildToolSchema builds the input schema from In and verifies both In and Out.
+// The In/Out shape is checked against the static type (reflect.TypeFor) rather
+// than a zero value, so the verdict is deterministic even for types whose zero
+// value is nil (e.g. interfaces or pointers) — a zero-value JSON probe would let
+// those slip through. In must be a struct; Out must be a struct or map. The
+// returned Parameter is the input object schema.
+func buildToolSchema[In, Out any]() (*Parameter, error) {
+	if err := assertObjectKind(reflect.TypeFor[In](), "In", false); err != nil {
+		return nil, err
+	}
+	if err := assertObjectKind(reflect.TypeFor[Out](), "Out", true); err != nil {
+		return nil, err
+	}
+
+	inSchema, err := ToSchema(*new(In))
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to build input schema", goerr.V("type", reflect.TypeFor[In]().String()))
+	}
+
+	return inSchema, nil
+}
+
+// assertObjectKind verifies that t (after unwrapping pointers) describes a JSON
+// object. Structs always qualify; maps qualify only when allowMap is set (Out can
+// be a map[string]any result, but a map In would produce a property-less schema).
+func assertObjectKind(t reflect.Type, role string, allowMap bool) error {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		return nil
+	case reflect.Map:
+		if allowMap {
+			return nil
+		}
+	}
+
+	want := "a struct"
+	if allowMap {
+		want = "a struct or map"
+	}
+	return goerr.Wrap(ErrInvalidToolType, role+" must be "+want,
+		goerr.V("type", t.String()), goerr.V("kind", t.Kind().String()))
+}
+
+// toResultMap converts a typed tool result into the wire map[string]any form. A
+// map[string]any is returned as-is to preserve the existing tool style and avoid
+// a needless round-trip; any other type is converted via JSON and therefore must
+// encode to a JSON object (a struct or map), otherwise ErrInvalidToolType.
+func toResultMap[Out any](out Out) (map[string]any, error) {
+	if m, ok := any(out).(map[string]any); ok {
+		return m, nil
+	}
+
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to encode tool result", goerr.V("type", fmt.Sprintf("%T", out)))
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, goerr.Wrap(ErrInvalidToolType, "tool result must encode to a JSON object",
+			goerr.V("type", fmt.Sprintf("%T", out)))
+	}
+	return m, nil
+}

--- a/typed_tool_test.go
+++ b/typed_tool_test.go
@@ -1,0 +1,442 @@
+package gollem_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gollem-dev/gollem"
+	"github.com/gollem-dev/gollem/mock"
+	"github.com/m-mizutani/gt"
+)
+
+// addArgs/addResult are typed tool definitions used across the typed-tool tests.
+// "a" is required and "b" is optional, so required/optional propagation is testable.
+type addArgs struct {
+	A float64 `json:"a" description:"First number" required:"true"`
+	B float64 `json:"b" description:"Second number"`
+}
+
+type addResult struct {
+	Result float64 `json:"result"`
+}
+
+func addHandler(_ context.Context, in addArgs) (addResult, error) {
+	return addResult{Result: in.A + in.B}, nil
+}
+
+// badTagArgs has an invalid struct tag so that schema inference fails.
+type badTagArgs struct {
+	A int `json:"a" min:"not-a-number"`
+}
+
+// richArgs exercises the full set of supported constraint tags, including a
+// nested struct and an array, to confirm they all propagate through ToolSchema.
+type richArgs struct {
+	Name string   `json:"name" description:"the name" required:"true" minLength:"1" maxLength:"10" pattern:"^[a-z]+$"`
+	Age  int      `json:"age" min:"0" max:"150"`
+	Role string   `json:"role" enum:"admin,user,guest"`
+	Tags []string `json:"tags" minItems:"1" maxItems:"5"`
+	Addr addr     `json:"addr"`
+}
+
+type addr struct {
+	City string `json:"city" required:"true"`
+}
+
+func mustPanic(t *testing.T, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, but the function did not panic")
+		}
+	}()
+	fn()
+}
+
+func TestToolSchema(t *testing.T) {
+	t.Run("struct In/Out succeeds and reflects tags", func(t *testing.T) {
+		schema, err := gollem.ToolSchema[addArgs, addResult]()
+		gt.NoError(t, err)
+		gt.Equal(t, gollem.TypeObject, schema.Type)
+
+		a := schema.Properties["a"]
+		gt.NotNil(t, a)
+		gt.Equal(t, gollem.TypeNumber, a.Type)
+		gt.True(t, a.Required)
+		gt.Equal(t, "First number", a.Description)
+
+		b := schema.Properties["b"]
+		gt.NotNil(t, b)
+		gt.Equal(t, gollem.TypeNumber, b.Type)
+		gt.False(t, b.Required)
+	})
+
+	t.Run("all constraint tags propagate through ToolSchema", func(t *testing.T) {
+		schema, err := gollem.ToolSchema[richArgs, addResult]()
+		gt.NoError(t, err)
+		p := schema.Properties
+
+		// string: description, required, length, pattern
+		gt.Equal(t, "the name", p["name"].Description)
+		gt.True(t, p["name"].Required)
+		gt.Equal(t, 1, *p["name"].MinLength)
+		gt.Equal(t, 10, *p["name"].MaxLength)
+		gt.Equal(t, "^[a-z]+$", p["name"].Pattern)
+
+		// integer: min/max
+		gt.Equal(t, float64(0), *p["age"].Minimum)
+		gt.Equal(t, float64(150), *p["age"].Maximum)
+
+		// enum
+		gt.Equal(t, []string{"admin", "user", "guest"}, p["role"].Enum)
+
+		// array: item type + size constraints
+		gt.Equal(t, gollem.TypeArray, p["tags"].Type)
+		gt.Equal(t, gollem.TypeString, p["tags"].Items.Type)
+		gt.Equal(t, 1, *p["tags"].MinItems)
+		gt.Equal(t, 5, *p["tags"].MaxItems)
+
+		// nested struct: recursive properties + required
+		gt.Equal(t, gollem.TypeObject, p["addr"].Type)
+		gt.True(t, p["addr"].Properties["city"].Required)
+	})
+
+	t.Run("map[string]any Out is accepted", func(t *testing.T) {
+		schema, err := gollem.ToolSchema[addArgs, map[string]any]()
+		gt.NoError(t, err)
+		gt.Equal(t, gollem.TypeObject, schema.Type)
+	})
+
+	t.Run("scalar In is rejected", func(t *testing.T) {
+		_, err := gollem.ToolSchema[string, addResult]()
+		gt.Error(t, err)
+		gt.True(t, errors.Is(err, gollem.ErrInvalidToolType))
+	})
+
+	t.Run("map In is rejected", func(t *testing.T) {
+		// A map In would yield a property-less schema, so it is not a valid input type.
+		_, err := gollem.ToolSchema[map[string]any, addResult]()
+		gt.Error(t, err)
+		gt.True(t, errors.Is(err, gollem.ErrInvalidToolType))
+	})
+
+	t.Run("scalar Out is rejected", func(t *testing.T) {
+		_, err := gollem.ToolSchema[addArgs, string]()
+		gt.Error(t, err)
+		gt.True(t, errors.Is(err, gollem.ErrInvalidToolType))
+	})
+
+	t.Run("interface Out is rejected", func(t *testing.T) {
+		// any has a nil zero value; a zero-value probe would miss it, but the
+		// reflect-based check rejects it deterministically.
+		_, err := gollem.ToolSchema[addArgs, any]()
+		gt.Error(t, err)
+		gt.True(t, errors.Is(err, gollem.ErrInvalidToolType))
+	})
+
+	t.Run("invalid struct tag is rejected", func(t *testing.T) {
+		_, err := gollem.ToolSchema[badTagArgs, addResult]()
+		gt.Error(t, err)
+	})
+}
+
+func TestMustToolSchema(t *testing.T) {
+	t.Run("returns schema for valid types", func(t *testing.T) {
+		schema := gollem.MustToolSchema[addArgs, addResult]()
+		gt.NotNil(t, schema)
+		gt.Equal(t, gollem.TypeObject, schema.Type)
+	})
+
+	t.Run("panics for invalid types", func(t *testing.T) {
+		mustPanic(t, func() {
+			_ = gollem.MustToolSchema[string, addResult]()
+		})
+	})
+}
+
+func TestNewTool(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("spec reflects name, description and inferred parameters", func(t *testing.T) {
+		tool, err := gollem.NewTool("add", "Adds two numbers", addHandler)
+		gt.NoError(t, err)
+
+		spec := tool.Spec()
+		gt.Equal(t, "add", spec.Name)
+		gt.Equal(t, "Adds two numbers", spec.Description)
+		gt.Equal(t, gollem.TypeNumber, spec.Parameters["a"].Type)
+		gt.True(t, spec.Parameters["a"].Required)
+	})
+
+	t.Run("run decodes args and converts struct result", func(t *testing.T) {
+		var got addArgs
+		tool, err := gollem.NewTool("add", "Adds two numbers",
+			func(_ context.Context, in addArgs) (addResult, error) {
+				got = in
+				return addResult{Result: in.A + in.B}, nil
+			})
+		gt.NoError(t, err)
+
+		out, err := tool.Run(ctx, map[string]any{"a": float64(2), "b": float64(3)})
+		gt.NoError(t, err)
+		gt.Equal(t, float64(2), got.A)
+		gt.Equal(t, float64(3), got.B)
+		gt.Equal(t, float64(5), out["result"].(float64))
+	})
+
+	t.Run("map result is passed through", func(t *testing.T) {
+		tool, err := gollem.NewTool("echo", "Echoes input",
+			func(_ context.Context, in addArgs) (map[string]any, error) {
+				return map[string]any{"sum": in.A + in.B}, nil
+			})
+		gt.NoError(t, err)
+
+		out, err := tool.Run(ctx, map[string]any{"a": float64(4), "b": float64(1)})
+		gt.NoError(t, err)
+		gt.Equal(t, float64(5), out["sum"].(float64))
+	})
+
+	t.Run("decode failure is propagated", func(t *testing.T) {
+		tool, err := gollem.NewTool("add", "Adds two numbers", addHandler)
+		gt.NoError(t, err)
+
+		_, err = tool.Run(ctx, map[string]any{"a": "not-a-number"})
+		gt.Error(t, err)
+	})
+
+	t.Run("handler error is propagated", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		tool, err := gollem.NewTool("fail", "Always fails",
+			func(_ context.Context, _ addArgs) (addResult, error) {
+				return addResult{}, sentinel
+			})
+		gt.NoError(t, err)
+
+		_, err = tool.Run(ctx, map[string]any{"a": float64(1), "b": float64(2)})
+		gt.True(t, errors.Is(err, sentinel))
+	})
+
+	t.Run("invalid In type returns error", func(t *testing.T) {
+		_, err := gollem.NewTool("bad", "bad",
+			func(_ context.Context, _ string) (addResult, error) {
+				return addResult{}, nil
+			})
+		gt.Error(t, err)
+		gt.True(t, errors.Is(err, gollem.ErrInvalidToolType))
+	})
+
+	t.Run("empty name returns error", func(t *testing.T) {
+		_, err := gollem.NewTool("", "no name", addHandler)
+		gt.Error(t, err)
+	})
+}
+
+func TestNewToolRejectsConstraintViolations(t *testing.T) {
+	// Proves that a NewTool-produced spec enforces every constraint kind, not just
+	// types: the inferred schema, run through the standard ValidateArgs, rejects
+	// violating input. (ValidateArgs is what executeToolCall runs before the handler.)
+	tool, err := gollem.NewTool("rich", "rich tool",
+		func(_ context.Context, _ richArgs) (addResult, error) {
+			return addResult{}, nil
+		})
+	gt.NoError(t, err)
+	spec := tool.Spec()
+
+	validArgs := func() map[string]any {
+		return map[string]any{
+			"name": "abc",
+			"age":  float64(30),
+			"role": "admin",
+			"tags": []any{"x"},
+			"addr": map[string]any{"city": "Tokyo"},
+		}
+	}
+
+	t.Run("valid args pass", func(t *testing.T) {
+		gt.NoError(t, spec.ValidateArgs(validArgs()))
+	})
+
+	reject := func(mutate func(m map[string]any)) func(t *testing.T) {
+		return func(t *testing.T) {
+			m := validArgs()
+			mutate(m)
+			err := spec.ValidateArgs(m)
+			gt.Error(t, err)
+			gt.True(t, errors.Is(err, gollem.ErrToolArgsValidation))
+		}
+	}
+
+	t.Run("missing required", reject(func(m map[string]any) { delete(m, "name") }))
+	t.Run("enum violation", reject(func(m map[string]any) { m["role"] = "root" }))
+	t.Run("below minimum", reject(func(m map[string]any) { m["age"] = float64(-1) }))
+	t.Run("above maximum", reject(func(m map[string]any) { m["age"] = float64(200) }))
+	t.Run("too short", reject(func(m map[string]any) { m["name"] = "" }))
+	t.Run("pattern mismatch", reject(func(m map[string]any) { m["name"] = "ABC" }))
+	t.Run("too few items", reject(func(m map[string]any) { m["tags"] = []any{} }))
+	t.Run("nested required missing", reject(func(m map[string]any) { m["addr"] = map[string]any{} }))
+}
+
+func TestMustNewTool(t *testing.T) {
+	t.Run("returns tool for valid definition", func(t *testing.T) {
+		tool := gollem.MustNewTool("add", "Adds two numbers", addHandler)
+		gt.NotNil(t, tool)
+		gt.Equal(t, "add", tool.Spec().Name)
+	})
+
+	t.Run("panics for invalid definition", func(t *testing.T) {
+		mustPanic(t, func() {
+			_ = gollem.MustNewTool("bad", "bad",
+				func(_ context.Context, _ string) (addResult, error) {
+					return addResult{}, nil
+				})
+		})
+	})
+}
+
+func TestNewToolWithMockLLM(t *testing.T) {
+	t.Run("definition propagates and handler receives typed input", func(t *testing.T) {
+		var gotIn addArgs
+		handlerCalled := false
+		tool, err := gollem.NewTool("add", "Adds two numbers",
+			func(_ context.Context, in addArgs) (addResult, error) {
+				gotIn = in
+				handlerCalled = true
+				return addResult{Result: in.A + in.B}, nil
+			})
+		gt.NoError(t, err)
+
+		var propagated gollem.ToolSpec
+		specCaptured := false
+		callCount := 0
+		mockClient := &mock.LLMClientMock{
+			NewSessionFunc: func(_ context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+				// The agent passes tools to the session via WithSessionTools; inspect
+				// what is actually handed to the LLM to confirm the inferred schema.
+				cfg := gollem.NewSessionConfig(options...)
+				for _, tl := range cfg.Tools() {
+					if tl.Spec().Name == "add" {
+						propagated = tl.Spec()
+						specCaptured = true
+					}
+				}
+
+				return &mock.SessionMock{
+					GenerateFunc: func(_ context.Context, _ []gollem.Input, _ ...gollem.GenerateOption) (*gollem.Response, error) {
+						callCount++
+						if callCount == 1 {
+							return &gollem.Response{
+								FunctionCalls: []*gollem.FunctionCall{
+									{
+										ID:        "call_add_1",
+										Name:      "add",
+										Arguments: map[string]any{"a": float64(2), "b": float64(3)},
+									},
+								},
+							}, nil
+						}
+						return &gollem.Response{Texts: []string{"done"}}, nil
+					},
+				}, nil
+			},
+		}
+
+		agent := gollem.New(mockClient, gollem.WithTools(tool), gollem.WithLoopLimit(5))
+		_, err = agent.Execute(t.Context(), gollem.Text("add 2 and 3"))
+		gt.NoError(t, err)
+
+		// Tool definition propagated to the LLM exactly as inferred from addArgs.
+		gt.True(t, specCaptured)
+		gt.Equal(t, "add", propagated.Name)
+		gt.Equal(t, "Adds two numbers", propagated.Description)
+		gt.Equal(t, gollem.TypeNumber, propagated.Parameters["a"].Type)
+		gt.True(t, propagated.Parameters["a"].Required)
+		gt.Equal(t, "First number", propagated.Parameters["a"].Description)
+		gt.False(t, propagated.Parameters["b"].Required)
+
+		// Handler received decoded, correctly typed values.
+		gt.True(t, handlerCalled)
+		gt.Equal(t, float64(2), gotIn.A)
+		gt.Equal(t, float64(3), gotIn.B)
+	})
+
+	t.Run("invalid args are blocked before the handler runs", func(t *testing.T) {
+		handlerCalled := false
+		tool, err := gollem.NewTool("add", "Adds two numbers",
+			func(_ context.Context, in addArgs) (addResult, error) {
+				handlerCalled = true
+				return addResult{Result: in.A + in.B}, nil
+			})
+		gt.NoError(t, err)
+
+		callCount := 0
+		mockClient := &mock.LLMClientMock{
+			NewSessionFunc: func(_ context.Context, _ ...gollem.SessionOption) (gollem.Session, error) {
+				return &mock.SessionMock{
+					GenerateFunc: func(_ context.Context, _ []gollem.Input, _ ...gollem.GenerateOption) (*gollem.Response, error) {
+						callCount++
+						if callCount == 1 {
+							// "a" is required but the wrong type; ValidateArgs must reject it.
+							return &gollem.Response{
+								FunctionCalls: []*gollem.FunctionCall{
+									{ID: "call_add_1", Name: "add", Arguments: map[string]any{"a": "not-a-number"}},
+								},
+							}, nil
+						}
+						return &gollem.Response{Texts: []string{"done"}}, nil
+					},
+				}, nil
+			},
+		}
+
+		agent := gollem.New(mockClient, gollem.WithTools(tool), gollem.WithLoopLimit(5))
+		_, err = agent.Execute(t.Context(), gollem.Text("add"))
+		gt.NoError(t, err)
+		gt.False(t, handlerCalled)
+	})
+
+	t.Run("with validation disabled, missing required reaches handler as zero value", func(t *testing.T) {
+		// Pins the documented behavior: WithDisableArgsValidation skips ValidateArgs,
+		// and decode does not enforce required, so a missing field arrives as its zero value.
+		var gotIn addArgs
+		handlerCalled := false
+		tool, err := gollem.NewTool("add", "Adds two numbers",
+			func(_ context.Context, in addArgs) (addResult, error) {
+				gotIn = in
+				handlerCalled = true
+				return addResult{Result: in.A + in.B}, nil
+			})
+		gt.NoError(t, err)
+
+		callCount := 0
+		mockClient := &mock.LLMClientMock{
+			NewSessionFunc: func(_ context.Context, _ ...gollem.SessionOption) (gollem.Session, error) {
+				return &mock.SessionMock{
+					GenerateFunc: func(_ context.Context, _ []gollem.Input, _ ...gollem.GenerateOption) (*gollem.Response, error) {
+						callCount++
+						if callCount == 1 {
+							// "a" (required) omitted entirely.
+							return &gollem.Response{
+								FunctionCalls: []*gollem.FunctionCall{
+									{ID: "call_add_1", Name: "add", Arguments: map[string]any{"b": float64(3)}},
+								},
+							}, nil
+						}
+						return &gollem.Response{Texts: []string{"done"}}, nil
+					},
+				}, nil
+			},
+		}
+
+		agent := gollem.New(mockClient,
+			gollem.WithTools(tool),
+			gollem.WithLoopLimit(5),
+			gollem.WithDisableArgsValidation(),
+		)
+		_, err = agent.Execute(t.Context(), gollem.Text("add"))
+		gt.NoError(t, err)
+		gt.True(t, handlerCalled)
+		gt.Equal(t, float64(0), gotIn.A)
+		gt.Equal(t, float64(3), gotIn.B)
+	})
+}


### PR DESCRIPTION
## Summary

Adds type-safe tool definitions so tool authors no longer hand-write a `ToolSpec`
and then perform manual `args["x"].(T)` assertions inside `Run` — two sources of
truth that can drift, with a panic risk on a wrong assertion.

This is a purely additive change: the `Tool` interface and all existing tools/MCP
are untouched.

## API

- `NewTool[In, Out](name, description string, run func(ctx, In) (Out, error)) (Tool, error)`
  — builds a `Tool` from a typed handler. The input schema is inferred from `In`
  (reusing `ToSchema`, same struct tags as `Query[T]`), and the handler receives a
  decoded `In` instead of a raw map.
- `MustNewTool[In, Out](...) Tool` — panic variant for static registration / slice literals.
- `ToolSchema[In, Out]() (*Parameter, error)` / `MustToolSchema[In, Out]() *Parameter`
  — infer and validate a tool's `In`/`Out` types (the latter mirrors `MustToSchema`).
- New sentinel error `ErrInvalidToolType`.

## Design notes

- `In` must be a **struct**. A map is rejected: it would yield a property-less
  schema (no argument info to the LLM) while giving none of the type safety.
- `Out` must encode to a JSON object (struct or `map[string]any`). A `map[string]any`
  result is passed through unchanged, so existing tools can adopt `NewTool`
  incrementally by keeping their map output.
- `In`/`Out` shape is validated against the **static type** (`reflect.TypeFor`),
  not a zero value, so types whose zero value is nil (e.g. `any`) are rejected
  deterministically.
- `In`→handler bridging is a JSON round-trip (same tags as the schema, so naming
  cannot drift). Argument validation against the schema still runs before the
  handler by default (`executeToolCall`); the typed decode is the safety net behind it.

## Tests

- Schema inference: all constraint tags propagate (enum / min / max / minLength /
  maxLength / pattern / minItems / maxItems, nested structs, arrays).
- Type rejection: scalar `In`, map `In`, scalar `Out`, interface `Out`, invalid tag.
- Constraint enforcement: a `NewTool`-produced spec rejects every constraint
  violation (required / enum / range / length / pattern / items / nested required).
- MockLLM integration: the inferred tool definition propagates to the LLM
  (`NewSessionConfig(options...).Tools()`), the handler receives decoded typed input,
  invalid args are blocked before the handler, and with `WithDisableArgsValidation`
  a missing required field arrives as its zero value.

## Out of scope (future work)

- A `go vet` / golangci-lint analyzer for build-time detection of unfit `In`/`Out`
  types. This change keeps detection at runtime (`NewTool` error / `Must*` panic).

## Docs

- `docs/tools.md`: new "Type-safe Tools with `NewTool`" section.
- `docs/schema.md`: `ToolSchema` / `MustToolSchema`.
- `examples/tools/main.go` rewritten to use typed handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
