### PR TITLE
docs: document MustToolSchema as a startup assertion

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -90,9 +90,33 @@ agent := gollem.New(client, gollem.WithTools(
 ))
 ```
 
-To validate a tool's `In`/`Out` types without constructing the tool (for example in
-a test), use `ToolSchema[In, Out]()` (returns an error) or `MustToolSchema[In, Out]()`
-(panics). Both reuse the same inference, so they agree with what `NewTool` produces.
+### Validating Tool Types
+
+To validate a tool's `In`/`Out` types without constructing the tool, use
+`ToolSchema[In, Out]()` (returns an error) or `MustToolSchema[In, Out]()` (panics).
+Both reuse the same inference as `NewTool`, so they agree with what it produces.
+
+The primary use is a **startup assertion**: a malformed `In`/`Out` type (a bad
+struct tag, a scalar type, etc.) is a programming error, and you want it to surface
+when the program starts rather than on the first LLM call. Declare a package-level
+assertion so the binary fails to start if the types ever become invalid:
+
+```go
+// Fail fast at package initialization if greetArgs/greetResult ever stop
+// forming a valid tool schema (e.g. a struct tag is broken in a refactor).
+var _ = gollem.MustToolSchema[greetArgs, greetResult]()
+```
+
+In a test, prefer the error-returning `ToolSchema` so the failure is reported as a
+test failure rather than a panic:
+
+```go
+func TestGreetToolSchema(t *testing.T) {
+    if _, err := gollem.ToolSchema[greetArgs, greetResult](); err != nil {
+        t.Fatalf("invalid tool schema: %v", err)
+    }
+}
+```
 
 > [!NOTE]
 > `ToolSchema` (tool input/output check) is distinct from `ToSchema` (single


### PR DESCRIPTION
## Why

`docs/tools.md` mentioned `ToolSchema` / `MustToolSchema` only as a way to "validate a tool's In/Out types (for example in a test)". This buried the primary intended use — a **startup assertion** that fails fast when a typed tool's `In`/`Out` types stop forming a valid schema (e.g. a struct tag is broken in a refactor). The behavior is described in the code comment (`typed_tool.go`) but was missing from the docs, so it was easy to overlook.

## What

- Split the `ToolSchema` / `MustToolSchema` paragraph into a dedicated `### Validating Tool Types` subsection.
- Lead with the startup-assertion use case, with a package-level `var _ = gollem.MustToolSchema[...]()` example.
- Keep the test-time guidance as the secondary case, recommending the error-returning `ToolSchema` so failures surface as test failures rather than panics.

Docs-only change; no Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)