### PR TITLE
fix(history.go): deep-copy MessageContent.Meta in Clone

### DIFF
--- a/history.go
+++ b/history.go
@@ -97,7 +97,12 @@ func cloneMessage(m Message) Message {
 		for i, c := range m.Contents {
 			dataCopy := make(json.RawMessage, len(c.Data))
 			copy(dataCopy, c.Data)
-			clone.Contents[i] = MessageContent{Type: c.Type, Data: dataCopy}
+			var metaCopy json.RawMessage
+			if c.Meta != nil {
+				metaCopy = make(json.RawMessage, len(c.Meta))
+				copy(metaCopy, c.Meta)
+			}
+			clone.Contents[i] = MessageContent{Type: c.Type, Data: dataCopy, Meta: metaCopy}
 		}
 	}
 

--- a/history_test.go
+++ b/history_test.go
@@ -789,3 +789,32 @@ func TestHistoryCloneWithCurrentVersion(t *testing.T) {
 	gt.Equal(t, original.LLType, cloned.LLType)
 	gt.Equal(t, original.Version, cloned.Version)
 }
+
+// TestClonePreservesContentMeta verifies that History.Clone performs a true deep
+// copy of every MessageContent field, including Meta (which carries Gemini's
+// ThoughtSignature and Claude content-block metadata).
+func TestClonePreservesContentMeta(t *testing.T) {
+	meta := json.RawMessage(`{"thought_signature":"YWJjZA=="}`)
+	original := &gollem.History{
+		LLType:  gollem.LLMTypeGemini,
+		Version: gollem.HistoryVersion,
+		Messages: []gollem.Message{
+			{
+				Role: gollem.RoleAssistant,
+				Contents: []gollem.MessageContent{
+					{
+						Type: gollem.MessageContentTypeThinking,
+						Data: json.RawMessage(`{"text":"reasoning"}`),
+						Meta: meta,
+					},
+				},
+			},
+		},
+	}
+
+	cloned := original.Clone()
+
+	// Data was already copied; Meta must be too.
+	gt.Equal(t, original.Messages[0].Contents[0].Data, cloned.Messages[0].Contents[0].Data)
+	gt.Equal(t, original.Messages[0].Contents[0].Meta, cloned.Messages[0].Contents[0].Meta)
+}


### PR DESCRIPTION
## Problem

`(*History).Clone()` → `cloneMessage` is documented as returning "a deep copy of m", but it omits the `MessageContent.Meta` field. It deep-copies `Role`, `Name`, `Contents[i].Data`, and `Metadata`, but builds each content as:

```go
clone.Contents[i] = MessageContent{Type: c.Type, Data: dataCopy}
```

so the clone's `Meta` is always `nil`.

`Meta` isn't cosmetic — it carries provider-specific metadata that must be echoed back on later turns:
- Gemini (`llm/gemini/convert_message.go`): `partMeta{Thought, ThoughtSignature}` — thought signatures that thinking models require on subsequent turns.
- Claude (`llm/claude/convert_message.go`): `claudePartMeta` content-block metadata.

`gollem.go` passes `cfg.history.Clone()` into `StrategyState.History` on every iteration of the agent loop, so ReAct / Plan-&-Execute / Reflexion (and any external caller of the exported `Clone`) receive history with thought signatures stripped — degrading Gemini thinking + tool-use continuity.

Root cause: classic "new struct field forgotten in the deep copy" — `Meta` (`json.RawMessage`) was added after `cloneMessage` was written.

## Fix

Copy `Meta` alongside `Data`, preserving `nil`-ness:

```go
var metaCopy json.RawMessage
if c.Meta != nil {
    metaCopy = make(json.RawMessage, len(c.Meta))
    copy(metaCopy, c.Meta)
}
clone.Contents[i] = MessageContent{Type: c.Type, Data: dataCopy, Meta: metaCopy}
```

## Tests

Added `TestClonePreservesContentMeta` to `history_test.go` (the existing `TestHistoryCloneWithCurrentVersion` only checks `LLType`/`Version`, never `Contents`). It clones a history whose content has a `Meta` (a Gemini thought signature) and asserts both `Data` and `Meta` survive.

- Before the fix it fails (`Meta` comes back `nil`).
- After, it passes:

```
$ go test -run 'TestClonePreservesContentMeta|TestHistoryClone' .
ok  github.com/gollem-dev/gollem
```

`go test .` (full root package) passes with no regressions; `go vet .` clean.
