### PR TITLE
feat: add WithQueryPromptCache and pin prompt-cache trace contract

### DIFF
--- a/docs/prompt-cache.md
+++ b/docs/prompt-cache.md
@@ -45,10 +45,13 @@ log.Printf("input=%d (cached read=%d, cache write=%d) output=%d",
     resp.CacheCreationInputToken, resp.OutputToken)
 ```
 
-The same values are recorded on trace spans (`trace/logger` emits
-`cache_creation_input_tokens` / `cache_read_input_tokens`; `trace/otel` sets
-`llm.cache_creation_input_tokens` / `llm.cache_read_input_tokens`). They are
-omitted when zero.
+The same values are recorded on trace spans through
+`trace.LLMCallData.CacheCreationInputTokens` / `CacheReadInputTokens`
+(`trace/logger` emits `cache_creation_input_tokens` / `cache_read_input_tokens`;
+`trace/otel` sets `llm.cache_creation_input_tokens` /
+`llm.cache_read_input_tokens`). They are omitted when zero. The same provider
+asymmetry applies: `CacheCreationInputTokens` is reported by Claude only, so `0`
+on OpenAI or Gemini does not mean the cache missed.
 
 ## Enabling Claude prompt caching
 
@@ -64,7 +67,19 @@ or on a standalone session:
 session, err := client.NewSession(ctx, gollem.WithSessionPromptCache(true))
 ```
 
-Both default to disabled. When enabled, gollem adds `cache_control` breakpoints
+or on a one-shot structured query:
+
+```go
+resp, err := gollem.Query[Answer](ctx, client, prompt,
+    gollem.WithQuerySystemPrompt(sharedSystemPrompt),
+    gollem.WithQueryPromptCache(true),
+)
+```
+
+A single query rarely hits the cache on its own; this pays off for recurring
+queries that share the same system prompt.
+
+All three default to disabled. When enabled, gollem adds `cache_control` breakpoints
 to the Claude request in up to three places:
 
 - the **system prompt** (last block),

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -99,6 +99,7 @@ fmt.Printf("Tokens used: %d input, %d output\n",
 | `WithQuerySystemPrompt(string)` | Set the system prompt for the query |
 | `WithQueryHistory(*History)` | Provide conversation history |
 | `WithQueryMaxRetry(int)` | Maximum retries on JSON parse failure (default: 3) |
+| `WithQueryPromptCache(bool)` | Enable provider prompt caching for the query's session (default: disabled, see [Prompt Caching](prompt-cache.md)) |
 
 ## Session-Based Typed Query with `SessionQuery[T]()`
 

--- a/llm/claude/client_test.go
+++ b/llm/claude/client_test.go
@@ -771,6 +771,53 @@ func TestClaudePromptCacheWiring(t *testing.T) {
 	t.Run("disabled leaves request unmarked", runTest(false))
 }
 
+// captureHandler records the *trace.LLMCallData handed to EndLLMCall. Asserting on
+// the handler argument pins the contract that consumers actually depend on; reading
+// it back from a Recorder span would instead prove how the Recorder stores it.
+type captureHandler struct {
+	trace.Handler
+	llmCall  *trace.LLMCallData
+	llmErr   error
+	endCalls int
+}
+
+func newCaptureHandler() *captureHandler {
+	return &captureHandler{Handler: trace.New()}
+}
+
+func (h *captureHandler) EndLLMCall(ctx context.Context, data *trace.LLMCallData, err error) {
+	h.endCalls++
+	h.llmCall = data
+	h.llmErr = err
+	h.Handler.EndLLMCall(ctx, data, err)
+}
+
+// start opens the root agent span and registers h on the returned context, so
+// llm_call spans created by the session have a parent.
+func (h *captureHandler) start(ctx context.Context) context.Context {
+	return trace.WithHandler(h.StartAgentExecute(ctx), h)
+}
+
+// llmCallData returns the captured data, failing the test when EndLLMCall was
+// never called with it.
+func (h *captureHandler) llmCallData(t *testing.T) *trace.LLMCallData {
+	t.Helper()
+	if h.llmCall == nil {
+		t.Fatal("EndLLMCall did not receive LLMCallData")
+	}
+	return h.llmCall
+}
+
+// cacheTraceCase pins one Claude usage shape to the token counts that both the
+// response and the trace data must report for it.
+type cacheTraceCase struct {
+	usage        anthropic.Usage
+	wantInput    int
+	wantOutput   int
+	wantCreation int
+	wantRead     int
+}
+
 func TestClaudeCacheTokenObservation(t *testing.T) {
 	mockClient := &apiClientMock{
 		MessagesNewFunc: func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
@@ -802,66 +849,189 @@ func TestClaudeCacheTokenObservation(t *testing.T) {
 	gt.Equal(t, 100, resp.CacheReadInputToken)
 }
 
-func TestClaudeStreamPromptCacheAndObservation(t *testing.T) {
-	var sent anthropic.MessageNewParams
-	mockClient := &apiClientMock{
-		MessagesNewFunc: func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
-			sent = params
-			return &anthropic.Message{
-				Content: []anthropic.ContentBlockUnion{{Type: "text", Text: "streamed"}},
-				Role:    "assistant",
-				Model:   "claude-3-opus-20240229",
-				Usage: anthropic.Usage{
-					InputTokens:          30,
-					OutputTokens:         5,
-					CacheReadInputTokens: 120,
+// TestClaudeGeneratePromptCacheTrace pins the blocking path, which is what
+// gollem.New uses by default (ResponseModeBlocking): the registered trace handler
+// must receive the prompt-cache token breakdown, not only the returned Response.
+func TestClaudeGeneratePromptCacheTrace(t *testing.T) {
+	runTest := func(tc cacheTraceCase) func(t *testing.T) {
+		return func(t *testing.T) {
+			mockClient := &apiClientMock{
+				MessagesNewFunc: func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
+					return &anthropic.Message{
+						Content: []anthropic.ContentBlockUnion{{Type: "text", Text: "ok"}},
+						Role:    "assistant",
+						Model:   "claude-3-opus-20240229",
+						Usage:   tc.usage,
+					}, nil
 				},
-			}, nil
+			}
+
+			cfg := gollem.NewSessionConfig(gollem.WithSessionPromptCache(true))
+			session, err := claude.NewSessionWithAPIClient(mockClient, cfg, "claude-3-opus-20240229")
+			gt.NoError(t, err)
+
+			h := newCaptureHandler()
+			ctx := h.start(context.Background())
+
+			resp, err := session.Generate(ctx, []gollem.Input{gollem.Text("hi")})
+			gt.NoError(t, err)
+
+			gt.Equal(t, tc.wantInput, resp.InputToken)
+			gt.Equal(t, tc.wantOutput, resp.OutputToken)
+			gt.Equal(t, tc.wantCreation, resp.CacheCreationInputToken)
+			gt.Equal(t, tc.wantRead, resp.CacheReadInputToken)
+
+			gt.Equal(t, 1, h.endCalls)
+			gt.Nil(t, h.llmErr)
+			data := h.llmCallData(t)
+			gt.Equal(t, tc.wantInput, data.InputTokens)
+			gt.Equal(t, tc.wantOutput, data.OutputTokens)
+			gt.Equal(t, tc.wantCreation, data.CacheCreationInputTokens)
+			gt.Equal(t, tc.wantRead, data.CacheReadInputTokens)
+		}
+	}
+
+	t.Run("cache write and read", runTest(cacheTraceCase{
+		usage: anthropic.Usage{
+			InputTokens:              40,
+			OutputTokens:             9,
+			CacheCreationInputTokens: 60,
+			CacheReadInputTokens:     200,
 		},
-	}
+		wantInput:    300, // 40 post-breakpoint + 60 written + 200 cached
+		wantOutput:   9,
+		wantCreation: 60,
+		wantRead:     200,
+	}))
 
-	cfg := gollem.NewSessionConfig(
-		gollem.WithSessionSystemPrompt("sys"),
-		gollem.WithSessionPromptCache(true),
-	)
-	session, err := claude.NewSessionWithAPIClient(mockClient, cfg, "claude-3-opus-20240229")
-	gt.NoError(t, err)
+	t.Run("cache read only", runTest(cacheTraceCase{
+		usage: anthropic.Usage{
+			InputTokens:          30,
+			OutputTokens:         5,
+			CacheReadInputTokens: 120,
+		},
+		wantInput:  150,
+		wantOutput: 5,
+		wantRead:   120,
+	}))
 
-	rec := trace.New()
-	ctx := rec.StartAgentExecute(context.Background())
-	ctx = trace.WithHandler(ctx, rec)
+	t.Run("no cache", runTest(cacheTraceCase{
+		usage: anthropic.Usage{
+			InputTokens:  25,
+			OutputTokens: 4,
+		},
+		wantInput:  25,
+		wantOutput: 4,
+	}))
 
-	ch, err := session.Stream(ctx, []gollem.Input{gollem.Text("hi")})
-	gt.NoError(t, err)
+	t.Run("api error ends the span without data", func(t *testing.T) {
+		errAPI := errors.New("boom")
+		mockClient := &apiClientMock{
+			MessagesNewFunc: func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
+				return nil, errAPI
+			},
+		}
 
-	var gotCacheRead, gotInput int
-	for resp := range ch {
-		gt.NoError(t, resp.Error)
-		if resp.InputToken > 0 {
-			gotInput = resp.InputToken
-			gotCacheRead = resp.CacheReadInputToken
+		session, err := claude.NewSessionWithAPIClient(mockClient, gollem.NewSessionConfig(), "claude-3-opus-20240229")
+		gt.NoError(t, err)
+
+		h := newCaptureHandler()
+		ctx := h.start(context.Background())
+
+		_, err = session.Generate(ctx, []gollem.Input{gollem.Text("hi")})
+		gt.Error(t, err)
+
+		// The handler must be told the call failed, with no token data to record.
+		gt.Equal(t, 1, h.endCalls)
+		gt.Nil(t, h.llmCall)
+		gt.True(t, errors.Is(h.llmErr, errAPI))
+	})
+}
+
+func TestClaudeStreamPromptCacheAndObservation(t *testing.T) {
+	runTest := func(tc cacheTraceCase) func(t *testing.T) {
+		return func(t *testing.T) {
+			var sent anthropic.MessageNewParams
+			mockClient := &apiClientMock{
+				MessagesNewFunc: func(ctx context.Context, params anthropic.MessageNewParams) (*anthropic.Message, error) {
+					sent = params
+					return &anthropic.Message{
+						Content: []anthropic.ContentBlockUnion{{Type: "text", Text: "streamed"}},
+						Role:    "assistant",
+						Model:   "claude-3-opus-20240229",
+						Usage:   tc.usage,
+					}, nil
+				},
+			}
+
+			cfg := gollem.NewSessionConfig(
+				gollem.WithSessionSystemPrompt("sys"),
+				gollem.WithSessionPromptCache(true),
+			)
+			session, err := claude.NewSessionWithAPIClient(mockClient, cfg, "claude-3-opus-20240229")
+			gt.NoError(t, err)
+
+			h := newCaptureHandler()
+			ctx := h.start(context.Background())
+
+			ch, err := session.Stream(ctx, []gollem.Input{gollem.Text("hi")})
+			gt.NoError(t, err)
+
+			var gotInput, gotOutput, gotCreation, gotRead int
+			for resp := range ch {
+				gt.NoError(t, resp.Error)
+				if resp.InputToken > 0 {
+					gotInput = resp.InputToken
+					gotOutput = resp.OutputToken
+					gotCreation = resp.CacheCreationInputToken
+					gotRead = resp.CacheReadInputToken
+				}
+			}
+			h.EndAgentExecute(ctx, nil)
+
+			// Streaming reports total input and the cache breakdown.
+			gt.Equal(t, tc.wantInput, gotInput)
+			gt.Equal(t, tc.wantOutput, gotOutput)
+			gt.Equal(t, tc.wantCreation, gotCreation)
+			gt.Equal(t, tc.wantRead, gotRead)
+
+			// The stream request carried the cache_control marker on the system prefix.
+			gt.Equal(t, anthropic.CacheControlEphemeralTTLTTL5m, sent.System[len(sent.System)-1].CacheControl.TTL)
+
+			// The registered trace handler receives the same breakdown.
+			gt.Equal(t, 1, h.endCalls)
+			gt.Nil(t, h.llmErr)
+			data := h.llmCallData(t)
+			gt.Equal(t, tc.wantInput, data.InputTokens)
+			gt.Equal(t, tc.wantOutput, data.OutputTokens)
+			gt.Equal(t, tc.wantCreation, data.CacheCreationInputTokens)
+			gt.Equal(t, tc.wantRead, data.CacheReadInputTokens)
 		}
 	}
-	rec.EndAgentExecute(ctx, nil)
 
-	// Streaming reports total input and the cached read count.
-	gt.Equal(t, 150, gotInput) // 30 post-breakpoint + 120 cached
-	gt.Equal(t, 120, gotCacheRead)
+	t.Run("cache read only", runTest(cacheTraceCase{
+		usage: anthropic.Usage{
+			InputTokens:          30,
+			OutputTokens:         5,
+			CacheReadInputTokens: 120,
+		},
+		wantInput:  150, // 30 post-breakpoint + 120 cached
+		wantOutput: 5,
+		wantRead:   120,
+	}))
 
-	// The stream request carried the cache_control marker on the system prefix.
-	gt.Equal(t, anthropic.CacheControlEphemeralTTLTTL5m, sent.System[len(sent.System)-1].CacheControl.TTL)
-
-	// Trace records the cache breakdown.
-	var llmSpan *trace.Span
-	for _, child := range rec.Trace().RootSpan.Children {
-		if child.Kind == trace.SpanKindLLMCall {
-			llmSpan = child
-			break
-		}
-	}
-	gt.Value(t, llmSpan).NotNil()
-	gt.Equal(t, 120, llmSpan.LLMCall.CacheReadInputTokens)
-	gt.Equal(t, 150, llmSpan.LLMCall.InputTokens)
+	t.Run("cache write and read", runTest(cacheTraceCase{
+		usage: anthropic.Usage{
+			InputTokens:              30,
+			OutputTokens:             5,
+			CacheCreationInputTokens: 45,
+			CacheReadInputTokens:     120,
+		},
+		wantInput:    195,
+		wantOutput:   5,
+		wantCreation: 45,
+		wantRead:     120,
+	}))
 }
 
 // TestClaudePromptCacheLive exercises the real Claude API to confirm that

--- a/llm/claude/export_test.go
+++ b/llm/claude/export_test.go
@@ -3,6 +3,7 @@ package claude
 import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/gollem-dev/gollem"
+	"github.com/m-mizutani/goerr/v2"
 )
 
 // Export convert functions for testing
@@ -50,6 +51,33 @@ func NewSessionWithAPIClient(client apiClient, cfg gollem.SessionConfig, model s
 			MaxTokens:   8192,
 		},
 		cfg: cfg,
+	}, nil
+}
+
+// NewVertexSessionWithClient creates a Vertex session backed by the given Anthropic
+// client for testing. NewWithVertex installs Google auth on its client, so tests
+// that need to drive the Vertex code path against an httptest server must supply
+// their own client here.
+func NewVertexSessionWithClient(client *anthropic.Client, cfg gollem.SessionConfig, model string) (*VertexAnthropicSession, error) {
+	var messages []anthropic.MessageParam
+	if cfg.History() != nil {
+		history, err := ToMessages(cfg.History())
+		if err != nil {
+			return nil, goerr.Wrap(err, "failed to convert history to anthropic.MessageParam")
+		}
+		messages = append(messages, history...)
+	}
+
+	return &VertexAnthropicSession{
+		client:       client,
+		defaultModel: model,
+		params: generationParameters{
+			Temperature: -1.0,
+			TopP:        -1.0,
+			MaxTokens:   8192,
+		},
+		cfg:      cfg,
+		messages: messages,
 	}, nil
 }
 

--- a/llm/claude/vertex_client_test.go
+++ b/llm/claude/vertex_client_test.go
@@ -2,10 +2,15 @@ package claude_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/gollem-dev/gollem"
 	"github.com/gollem-dev/gollem/llm/claude"
 	"github.com/m-mizutani/gt"
@@ -52,6 +57,90 @@ func TestNewWithVertex(t *testing.T) {
 		// If it succeeds, validate the configuration
 		gt.NotNil(t, client)
 	})
+}
+
+// vertexTraceResponse is a fixed Anthropic message payload with a prompt-cache
+// usage breakdown. The Vertex path calls anthropic.Client directly instead of the
+// apiClient interface, so it is driven over the wire rather than with a mock.
+const vertexTraceResponse = `{
+  "id": "msg_test",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-sonnet-4@20250514",
+  "content": [{"type": "text", "text": "ok"}],
+  "stop_reason": "end_turn",
+  "usage": {
+    "input_tokens": 12,
+    "output_tokens": 3,
+    "cache_creation_input_tokens": 34,
+    "cache_read_input_tokens": 56
+  }
+}`
+
+func TestVertexGeneratePromptCacheTrace(t *testing.T) {
+	type systemBlock struct {
+		CacheControl map[string]any `json:"cache_control"`
+	}
+	type sentRequest struct {
+		System []systemBlock `json:"system"`
+	}
+
+	sentCh := make(chan sentRequest, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var sent sentRequest
+		if err := json.NewDecoder(r.Body).Decode(&sent); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		sentCh <- sent
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(vertexTraceResponse)); err != nil {
+			// The client has already gone away, so nothing can be recovered here.
+			// A truncated response surfaces as an error from Generate, which the
+			// assertions below catch.
+			return
+		}
+	}))
+	defer srv.Close()
+
+	client := anthropic.NewClient(
+		option.WithBaseURL(srv.URL),
+		option.WithAPIKey("test"),
+	)
+	cfg := gollem.NewSessionConfig(
+		gollem.WithSessionSystemPrompt("sys"),
+		gollem.WithSessionPromptCache(true),
+	)
+	session, err := claude.NewVertexSessionWithClient(&client, cfg, "claude-sonnet-4@20250514")
+	gt.NoError(t, err)
+
+	h := newCaptureHandler()
+	ctx := h.start(context.Background())
+
+	resp, err := session.Generate(ctx, []gollem.Input{gollem.Text("hi")})
+	gt.NoError(t, err)
+
+	gt.Equal(t, 102, resp.InputToken) // 12 post-breakpoint + 34 written + 56 cached
+	gt.Equal(t, 3, resp.OutputToken)
+	gt.Equal(t, 34, resp.CacheCreationInputToken)
+	gt.Equal(t, 56, resp.CacheReadInputToken)
+
+	// The registered trace handler receives the same breakdown.
+	gt.Equal(t, 1, h.endCalls)
+	gt.Nil(t, h.llmErr)
+	data := h.llmCallData(t)
+	gt.Equal(t, 102, data.InputTokens)
+	gt.Equal(t, 3, data.OutputTokens)
+	gt.Equal(t, 34, data.CacheCreationInputTokens)
+	gt.Equal(t, 56, data.CacheReadInputTokens)
+
+	// The request carried the cache_control marker on the system prefix.
+	sent := <-sentCh
+	if len(sent.System) == 0 {
+		t.Fatal("request carried no system prompt")
+	}
+	gt.NotNil(t, sent.System[len(sent.System)-1].CacheControl)
 }
 
 func TestVertexClient(t *testing.T) {

--- a/query.go
+++ b/query.go
@@ -25,6 +25,7 @@ type queryConfig struct {
 	systemPrompt string
 	history      *History
 	maxRetry     int // default: 3
+	promptCache  bool
 }
 
 // WithQuerySystemPrompt sets the system prompt for the query.
@@ -45,6 +46,15 @@ func WithQueryHistory(history *History) QueryOption {
 func WithQueryMaxRetry(n int) QueryOption {
 	return func(cfg *queryConfig) {
 		cfg.maxRetry = n
+	}
+}
+
+// WithQueryPromptCache enables provider prompt caching for the session created by
+// the query. Defaults to disabled. See WithSessionPromptCache for the per-provider
+// behavior.
+func WithQueryPromptCache(enabled bool) QueryOption {
+	return func(cfg *queryConfig) {
+		cfg.promptCache = enabled
 	}
 }
 
@@ -75,6 +85,9 @@ func Query[T any](ctx context.Context, client LLMClient, prompt string, opts ...
 	}
 	if cfg.history != nil {
 		sessionOpts = append(sessionOpts, WithSessionHistory(cfg.history))
+	}
+	if cfg.promptCache {
+		sessionOpts = append(sessionOpts, WithSessionPromptCache(true))
 	}
 
 	session, err := client.NewSession(ctx, sessionOpts...)

--- a/query_test.go
+++ b/query_test.go
@@ -110,6 +110,54 @@ func TestQueryWithHistory(t *testing.T) {
 	gt.Value(t, cfg.History()).Equal(history)
 }
 
+func TestQueryWithPromptCache(t *testing.T) {
+	type testCase struct {
+		opts            []gollem.QueryOption
+		wantPromptCache bool
+	}
+
+	runTest := func(tc testCase) func(t *testing.T) {
+		return func(t *testing.T) {
+			var capturedOpts []gollem.SessionOption
+			sessionMock := &mock.SessionMock{
+				GenerateFunc: func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {
+					return &gollem.Response{
+						Texts: []string{`{"name":"x","count":1}`},
+					}, nil
+				},
+			}
+			client := &mock.LLMClientMock{
+				NewSessionFunc: func(ctx context.Context, options ...gollem.SessionOption) (gollem.Session, error) {
+					capturedOpts = options
+					return sessionMock, nil
+				},
+			}
+
+			_, err := gollem.Query[testQueryResult](context.Background(), client, "test", tc.opts...)
+			gt.NoError(t, err)
+
+			cfg := buildSessionConfig(capturedOpts)
+			gt.Value(t, cfg.PromptCache()).Equal(tc.wantPromptCache)
+			gt.Value(t, cfg.ContentType()).Equal(gollem.ContentTypeJSON)
+			gt.Value(t, cfg.ResponseSchema()).NotEqual((*gollem.Parameter)(nil))
+		}
+	}
+
+	t.Run("enabled", runTest(testCase{
+		opts:            []gollem.QueryOption{gollem.WithQueryPromptCache(true)},
+		wantPromptCache: true,
+	}))
+
+	t.Run("explicitly disabled", runTest(testCase{
+		opts:            []gollem.QueryOption{gollem.WithQueryPromptCache(false)},
+		wantPromptCache: false,
+	}))
+
+	t.Run("unspecified defaults to disabled", runTest(testCase{
+		wantPromptCache: false,
+	}))
+}
+
 func TestQueryRetrySuccess(t *testing.T) {
 	callCount := 0
 	client := setupQueryMock(t, func(ctx context.Context, input []gollem.Input, opts ...gollem.GenerateOption) (*gollem.Response, error) {

--- a/trace/data.go
+++ b/trace/data.go
@@ -7,6 +7,12 @@ type LLMCallData struct {
 	Model        string `json:"model,omitempty"`
 
 	// Prompt-cache token breakdown. Omitted when zero for backward compatibility.
+	//
+	// CacheCreationInputTokens counts input tokens written to the cache on this
+	// call. Only Claude reports writes; it is always 0 for OpenAI and Gemini, so 0
+	// there does not mean the cache missed. CacheReadInputTokens (cache hits) is
+	// reported by all providers. InputTokens always counts total input, including
+	// both.
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 


### PR DESCRIPTION
Follow-ups to #156 (prompt caching), raised from a consumer repository that records the prompt-cache token breakdown from a `trace.Handler`.

## What changed

**Pin the trace contract on the paths that were untested.** `trace.LLMCallData` carries the prompt-cache token breakdown, but only the streaming path had a test for it, and that test only exercised `CacheReadInputTokens` with `CacheCreationInputTokens` stuck at 0. Since `gollem.New` defaults to `ResponseModeBlocking`, the untested path was the one most consumers actually use.

- `TestClaudeGeneratePromptCacheTrace` covers `Session.Generate` with cache write + read, read only, and no cache at all, plus an API-error case that pins `EndLLMCall(ctx, nil, err)`.
- `TestClaudeStreamPromptCacheAndObservation` now runs two cases, including one where a cache write occurs.
- `TestVertexGeneratePromptCacheTrace` covers `VertexAnthropicSession.Generate`. That path calls `anthropic.Client` directly rather than through the `apiClient` interface, so it is driven over the wire with `httptest` via a new test-only seam in `export_test.go`. It also pins that the Vertex request carries the `cache_control` marker, which had no coverage at all.

All three assert on the `*trace.LLMCallData` handed to `EndLLMCall` rather than reading it back from a `Recorder` span, so they fail if a provider stops populating the fields.

**Add `WithQueryPromptCache(bool)`.** `Query[T]` built its session options without any way to enable prompt caching, so callers could not use it at all through `Query`. This matters for recurring queries that share one system prompt.

**Document the provider asymmetry on `trace.LLMCallData`.** `gollem.Response` already noted that only Claude reports cache writes; the trace struct did not, so a handler author could read `CacheCreationInputTokens == 0` on OpenAI or Gemini as a cache miss.

## Not included

Exposing the `apiClient` interface (or a public `NewSessionWithAPIClient`) as a mock-injection seam was considered and declined: it would pull anthropic-sdk-go types into gollem's public contract, making SDK major updates breaking changes for gollem. The tests above give the regression coverage that motivated the request.

## Verification

`go vet ./...`, `go test ./...` (also with `-race` on the affected packages), `golangci-lint run ./...`, and `gosec -quiet ./...` all pass. The one remaining `golangci-lint` finding (`schema.go:88`, `reflect.Ptr` inline) predates this branch and is in an untouched file.
